### PR TITLE
#28 - test with release file

### DIFF
--- a/src/test/java/com/artipie/debian/DebianSliceITCase.java
+++ b/src/test/java/com/artipie/debian/DebianSliceITCase.java
@@ -31,6 +31,7 @@ import com.artipie.debian.http.DebianSlice;
 import com.artipie.http.rs.RsStatus;
 import com.artipie.http.slice.LoggingSlice;
 import com.artipie.vertx.VertxSliceServer;
+import com.jcabi.log.Logger;
 import io.vertx.reactivex.core.Vertx;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -40,7 +41,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsNot;
+import org.hamcrest.core.StringContains;
 import org.hamcrest.text.StringContainsInOrder;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -123,30 +127,42 @@ public final class DebianSliceITCase {
     }
 
     @Test
-    void searchWorks() throws IOException, InterruptedException {
-        new TestResource("pspp_1.2.0-3_amd64.deb")
-            .saveTo(this.storage, new Key.From("main", "pspp_1.2.0-3_amd64.deb"));
-        new TestResource("Packages.gz")
-            .saveTo(this.storage, new Key.From("dists/artipie/main/binary-amd64/Packages.gz"));
+    void searchWorks() throws Exception {
+        copyPackage("pspp_1.2.0-3_amd64.deb");
         this.cntn.execInContainer("apt-get", "update");
         MatcherAssert.assertThat(
-            this.cntn.execInContainer("apt-cache", "search", "pspp").getStdout(),
+            this.exec("apt-cache", "search", "pspp"),
             new StringContainsInOrder(new ListOf<>("pspp", "Statistical analysis tool"))
         );
     }
 
     @Test
-    void installWorks() throws IOException, InterruptedException {
-        new TestResource("aglfn_1.7-3_amd64.deb")
-            .saveTo(this.storage, new Key.From("main", "aglfn_1.7-3_amd64.deb"));
-        new TestResource("Packages.gz")
-            .saveTo(this.storage, new Key.From("dists/artipie/main/binary-amd64/Packages.gz"));
+    void installWorks() throws Exception {
+        copyPackage("aglfn_1.7-3_amd64.deb");
         this.cntn.execInContainer("apt-get", "update");
-        final Container.ExecResult res =
-            this.cntn.execInContainer("apt-get", "install", "-y", "aglfn");
         MatcherAssert.assertThat(
             "Package was downloaded and unpacked",
-            res.getStdout(),
+            this.exec("apt-get", "install", "-y", "aglfn"),
+            new StringContainsInOrder(new ListOf<>("Unpacking aglfn", "Setting up aglfn"))
+        );
+    }
+
+    @Test
+    void installWithInReleaseFileWorks() throws Exception {
+        this.copyPackage("aglfn_1.7-3_amd64.deb");
+        new TestResource("Release")
+            .saveTo(this.storage, new Key.From("dists/artipie/Release"));
+        MatcherAssert.assertThat(
+            "Release file is used on update the world",
+            this.exec("apt-get", "update"),
+            Matchers.allOf(
+                new StringContains("artipie/main amd64 Packages"),
+                new IsNot<>(new StringContains("artipie/main all Packages"))
+            )
+        );
+        MatcherAssert.assertThat(
+            "Package was downloaded and unpacked",
+            this.exec("apt-get", "install", "-y", "aglfn"),
             new StringContainsInOrder(new ListOf<>("Unpacking aglfn", "Setting up aglfn"))
         );
     }
@@ -166,19 +182,29 @@ public final class DebianSliceITCase {
             con.getResponseCode(),
             new IsEqual<>(Integer.parseInt(RsStatus.OK.code()))
         );
-        this.cntn.execInContainer("apt-get", "update");
-        final Container.ExecResult res =
-            this.cntn.execInContainer("apt-get", "install", "-y", "aglfn");
+        this.exec("apt-get", "update");
         MatcherAssert.assertThat(
             "Package was downloaded and unpacked",
-            res.getStdout(),
+            this.exec("apt-get", "install", "-y", "aglfn"),
             new StringContainsInOrder(new ListOf<>("Unpacking aglfn", "Setting up aglfn"))
         );
+    }
+
+    private void copyPackage(String s) {
+        new TestResource(s).saveTo(this.storage, new Key.From("main", s));
+        new TestResource("Packages.gz")
+            .saveTo(this.storage, new Key.From("dists/artipie/main/binary-amd64/Packages.gz"));
     }
 
     @AfterEach
     void stop() {
         this.server.stop();
         this.cntn.stop();
+    }
+
+    private String exec(final String... command) throws Exception {
+        final Container.ExecResult res = this.cntn.execInContainer(command);
+        Logger.debug(this, "Command:\n%s\nResult:\n%s", String.join(" ", command), res.toString());
+        return res.getStdout();
     }
 }

--- a/src/test/java/com/artipie/debian/DebianSliceITCase.java
+++ b/src/test/java/com/artipie/debian/DebianSliceITCase.java
@@ -128,7 +128,7 @@ public final class DebianSliceITCase {
 
     @Test
     void searchWorks() throws Exception {
-        copyPackage("pspp_1.2.0-3_amd64.deb");
+        this.copyPackage("pspp_1.2.0-3_amd64.deb");
         this.cntn.execInContainer("apt-get", "update");
         MatcherAssert.assertThat(
             this.exec("apt-cache", "search", "pspp"),
@@ -138,7 +138,7 @@ public final class DebianSliceITCase {
 
     @Test
     void installWorks() throws Exception {
-        copyPackage("aglfn_1.7-3_amd64.deb");
+        this.copyPackage("aglfn_1.7-3_amd64.deb");
         this.cntn.execInContainer("apt-get", "update");
         MatcherAssert.assertThat(
             "Package was downloaded and unpacked",
@@ -190,16 +190,16 @@ public final class DebianSliceITCase {
         );
     }
 
-    private void copyPackage(String s) {
-        new TestResource(s).saveTo(this.storage, new Key.From("main", s));
-        new TestResource("Packages.gz")
-            .saveTo(this.storage, new Key.From("dists/artipie/main/binary-amd64/Packages.gz"));
-    }
-
     @AfterEach
     void stop() {
         this.server.stop();
         this.cntn.stop();
+    }
+
+    private void copyPackage(final String pkg) {
+        new TestResource(pkg).saveTo(this.storage, new Key.From("main", pkg));
+        new TestResource("Packages.gz")
+            .saveTo(this.storage, new Key.From("dists/artipie/main/binary-amd64/Packages.gz"));
     }
 
     private String exec(final String... command) throws Exception {

--- a/src/test/resources/Release
+++ b/src/test/resources/Release
@@ -1,0 +1,5 @@
+Codename: artipie
+Architectures: amd64
+Components: main
+Date: Sat, 05 Dec 2020 10:35:57 UTC
+SHA256: b91aebb02060c606256206fb6085915f62563a8d78de6ad2873bf171611b5e1c


### PR DESCRIPTION
Part of #28 
Added IT for install with release file. How is this file used? Apt-get reads Architectures and Components fields and requests packages only from corresponding repository directories (in our case - only from amd64 as it's container architecture and our repo supports it according to this Release file). 