### PR TITLE
#28 - added Release index create/update for the repo

### DIFF
--- a/src/main/java/com/artipie/debian/Config.java
+++ b/src/main/java/com/artipie/debian/Config.java
@@ -74,12 +74,24 @@ public interface Config {
          * @param yaml Setting in yaml format
          */
         public FromYaml(final String name, final Optional<YamlMapping> yaml) {
-            this.name = name;
-            this.yaml = yaml.orElseThrow(
-                () -> new IllegalArgumentException(
-                    "Illegal config: `setting` section is required for debian repos"
+            this(
+                name,
+                yaml.orElseThrow(
+                    () -> new IllegalArgumentException(
+                        "Illegal config: `setting` section is required for debian repos"
+                    )
                 )
             );
+        }
+
+        /**
+         * Ctor.
+         * @param name Repository name
+         * @param yaml Setting in yaml format
+         */
+        public FromYaml(final String name, final YamlMapping yaml) {
+            this.name = name;
+            this.yaml = yaml;
         }
 
         @Override

--- a/src/main/java/com/artipie/debian/http/DebianSlice.java
+++ b/src/main/java/com/artipie/debian/http/DebianSlice.java
@@ -24,6 +24,7 @@
 package com.artipie.debian.http;
 
 import com.artipie.asto.Storage;
+import com.artipie.debian.Config;
 import com.artipie.http.Slice;
 import com.artipie.http.auth.Action;
 import com.artipie.http.auth.Authentication;
@@ -49,10 +50,10 @@ public final class DebianSlice extends Slice.Wrap {
     /**
      * Ctor.
      * @param storage Storage
-     * @param reponame Repository name
+     * @param config Repository configuration
      */
-    public DebianSlice(final Storage storage, final String reponame) {
-        this(storage, Permissions.FREE, Authentication.ANONYMOUS, reponame);
+    public DebianSlice(final Storage storage, final Config config) {
+        this(storage, Permissions.FREE, Authentication.ANONYMOUS, config);
     }
 
     /**
@@ -60,17 +61,17 @@ public final class DebianSlice extends Slice.Wrap {
      * @param storage Storage
      * @param perms Permissions
      * @param users Users
-     * @param reponame Repository name
+     * @param config Repository configuration
      * @checkstyle ParameterNumberCheck (5 lines)
      */
     public DebianSlice(final Storage storage, final Permissions perms,
-        final Authentication users, final String reponame) {
+        final Authentication users, final Config config) {
         super(
             new SliceRoute(
                 new RtRulePath(
                     new ByMethodsRule(RqMethod.GET),
                     new BasicAuthSlice(
-                        new SliceDownload(storage),
+                        new ReleaseSlice(new SliceDownload(storage), storage, config),
                         users,
                         new Permission.ByName(perms, Action.Standard.READ)
                     )
@@ -80,7 +81,7 @@ public final class DebianSlice extends Slice.Wrap {
                         new ByMethodsRule(RqMethod.PUT), new ByMethodsRule(RqMethod.POST)
                     ),
                     new BasicAuthSlice(
-                        new UpdateSlice(storage, reponame),
+                        new ReleaseSlice(new UpdateSlice(storage, config), storage, config),
                         users,
                         new Permission.ByName(perms, Action.Standard.WRITE)
                     )

--- a/src/main/java/com/artipie/debian/http/ReleaseSlice.java
+++ b/src/main/java/com/artipie/debian/http/ReleaseSlice.java
@@ -1,0 +1,98 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.debian.http;
+
+import com.artipie.asto.Key;
+import com.artipie.asto.Storage;
+import com.artipie.debian.Config;
+import com.artipie.debian.metadata.Release;
+import com.artipie.http.Response;
+import com.artipie.http.Slice;
+import com.artipie.http.async.AsyncResponse;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import org.reactivestreams.Publisher;
+
+/**
+ * Release slice decorator.
+ * Checks, whether Release index exists and creates it if necessary.
+ * @since 0.2
+ */
+public final class ReleaseSlice implements Slice {
+
+    /**
+     * Origin slice.
+     */
+    private final Slice origin;
+
+    /**
+     * Abstract storage.
+     */
+    private final Storage storage;
+
+    /**
+     * Repository configuration.
+     */
+    private final Config config;
+
+    /**
+     * Ctor.
+     * @param origin Origin
+     * @param asto Storage
+     * @param config Repository configuration
+     */
+    public ReleaseSlice(final Slice origin, final Storage asto, final Config config) {
+        this.origin = origin;
+        this.config = config;
+        this.storage = asto;
+    }
+
+    @Override
+    public Response response(
+        final String line,
+        final Iterable<Map.Entry<String, String>> headers,
+        final Publisher<ByteBuffer> body
+    ) {
+        return new AsyncResponse(
+            this.storage.exists(
+                new Key.From(String.format("dists/%s/Release", this.config.codename()))
+            ).thenCompose(
+                exists -> {
+                    final CompletionStage<Response> res;
+                    if (exists) {
+                        res = CompletableFuture.completedFuture(
+                            this.origin.response(line, headers, body)
+                        );
+                    } else {
+                        res = new Release.Asto(this.storage, this.config).create()
+                            .thenApply(nothing -> this.origin.response(line, headers, body));
+                    }
+                    return res;
+                }
+            )
+        );
+    }
+}

--- a/src/test/java/com/artipie/debian/DebianAuthSliceITCase.java
+++ b/src/test/java/com/artipie/debian/DebianAuthSliceITCase.java
@@ -23,6 +23,7 @@
  */
 package com.artipie.debian;
 
+import com.amihaiemil.eoyaml.Yaml;
 import com.artipie.asto.Storage;
 import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.asto.test.TestResource;
@@ -192,7 +193,13 @@ public final class DebianAuthSliceITCase {
                     new Authentication.Single(
                         DebianAuthSliceITCase.USER, DebianAuthSliceITCase.PSWD
                     ),
-                    "artipie"
+                    new Config.FromYaml(
+                        "artipie",
+                        Yaml.createYamlMappingBuilder()
+                            .add("Components", "main")
+                            .add("Architectures", "amd64")
+                            .build()
+                    )
                 )
             )
         );

--- a/src/test/java/com/artipie/debian/DebianSliceITCase.java
+++ b/src/test/java/com/artipie/debian/DebianSliceITCase.java
@@ -23,6 +23,7 @@
  */
 package com.artipie.debian;
 
+import com.amihaiemil.eoyaml.Yaml;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.memory.InMemoryStorage;
@@ -105,7 +106,18 @@ public final class DebianSliceITCase {
         this.storage = new InMemoryStorage();
         this.server = new VertxSliceServer(
             DebianSliceITCase.VERTX,
-            new LoggingSlice(new DebianSlice(this.storage, "artipie"))
+            new LoggingSlice(
+                new DebianSlice(
+                    this.storage,
+                    new Config.FromYaml(
+                        "artipie",
+                        Yaml.createYamlMappingBuilder()
+                            .add("Components", "main")
+                            .add("Architectures", "amd64")
+                            .build()
+                    )
+                )
+            )
         );
         this.port = this.server.start();
         Testcontainers.exposeHostPorts(this.port);

--- a/src/test/java/com/artipie/debian/http/UpdateSliceTest.java
+++ b/src/test/java/com/artipie/debian/http/UpdateSliceTest.java
@@ -23,12 +23,14 @@
  */
 package com.artipie.debian.http;
 
+import com.amihaiemil.eoyaml.Yaml;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.blocking.BlockingStorage;
 import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.asto.test.TestResource;
+import com.artipie.debian.Config;
 import com.artipie.http.Headers;
 import com.artipie.http.hm.RsHasStatus;
 import com.artipie.http.hm.SliceHasResponse;
@@ -70,7 +72,10 @@ class UpdateSliceTest {
     void uploadsAndCreatesIndex() {
         MatcherAssert.assertThat(
             "Response is OK",
-            new UpdateSlice(this.asto, "my_repo"),
+            new UpdateSlice(
+                this.asto,
+                new Config.FromYaml("my_repo", Yaml.createYamlMappingBuilder().build())
+            ),
             new SliceHasResponse(
                 new RsHasStatus(RsStatus.OK),
                 new RequestLine(RqMethod.PUT, "/main/aglfn_1.7-3_all.deb"),
@@ -96,7 +101,10 @@ class UpdateSliceTest {
         new TestResource("Packages.gz").saveTo(this.asto, new Key.From(key));
         MatcherAssert.assertThat(
             "Response is OK",
-            new UpdateSlice(this.asto, "deb_repo"),
+            new UpdateSlice(
+                this.asto,
+                new Config.FromYaml("deb_repo", Yaml.createYamlMappingBuilder().build())
+            ),
             new SliceHasResponse(
                 new RsHasStatus(RsStatus.OK),
                 new RequestLine(RqMethod.PUT, "/main/cm-super_0.3.4-14_all.deb"),
@@ -125,7 +133,10 @@ class UpdateSliceTest {
     void returnsErrorAndRemovesItem() {
         MatcherAssert.assertThat(
             "Response is internal error",
-            new UpdateSlice(this.asto, "my_repo"),
+            new UpdateSlice(
+                this.asto,
+                new Config.FromYaml("my_repo", Yaml.createYamlMappingBuilder().build())
+            ),
             new SliceHasResponse(
                 new RsHasStatus(RsStatus.INTERNAL_ERROR),
                 new RequestLine(RqMethod.PUT, "/main/corrupted.deb"),

--- a/src/test/java/com/artipie/debian/http/UpdateSliceTest.java
+++ b/src/test/java/com/artipie/debian/http/UpdateSliceTest.java
@@ -70,6 +70,7 @@ class UpdateSliceTest {
 
     @Test
     void uploadsAndCreatesIndex() {
+        this.asto.save(new Key.From("dists/my_repo/Release"), Content.EMPTY);
         MatcherAssert.assertThat(
             "Response is OK",
             new UpdateSlice(
@@ -97,6 +98,7 @@ class UpdateSliceTest {
 
     @Test
     void uploadsAndUpdatesIndex() throws IOException {
+        this.asto.save(new Key.From("dists/deb_repo/Release"), Content.EMPTY);
         final String key = "dists/deb_repo/main/binary-all/Packages.gz";
         new TestResource("Packages.gz").saveTo(this.asto, new Key.From(key));
         MatcherAssert.assertThat(


### PR DESCRIPTION
Part of #28 
Created `ReleaseSlice` slice decorator (test will be added later) to create absent Release index file of requests and made `Package` to update Release after Packages index was updated.