### PR TITLE
#28 - Release key

### DIFF
--- a/src/test/java/com/artipie/debian/metadata/PackageAstoTest.java
+++ b/src/test/java/com/artipie/debian/metadata/PackageAstoTest.java
@@ -171,6 +171,11 @@ class PackageAstoTest {
             this.count.incrementAndGet();
             return CompletableFuture.allOf();
         }
+
+        @Override
+        public Key key() {
+            throw new NotImplementedException("Not implemented");
+        }
     }
 
 }

--- a/src/test/java/com/artipie/debian/metadata/ReleaseAstoTest.java
+++ b/src/test/java/com/artipie/debian/metadata/ReleaseAstoTest.java
@@ -171,4 +171,18 @@ class ReleaseAstoTest {
             new IsEqual<>(String.join("\n", content))
         );
     }
+
+    @Test
+    void returnsReleaseIndexKey() {
+        MatcherAssert.assertThat(
+            new Release.Asto(
+                this.asto,
+                new Config.FromYaml(
+                    "deb-repo",
+                    Optional.of(Yaml.createYamlMappingBuilder().build())
+                )
+            ).key(),
+            new IsEqual<>(new Key.From("dists/deb-repo/Release"))
+        );
+    }
 }


### PR DESCRIPTION
Part of #28 
Added `key()` method to `Release` interface to avoid code repetition to obtaining this key.