### PR TITLE
#49 - do not pass decompressed bytes

### DIFF
--- a/src/main/java/com/artipie/debian/metadata/Package.java
+++ b/src/main/java/com/artipie/debian/metadata/Package.java
@@ -26,14 +26,17 @@ package com.artipie.debian.metadata;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
-import com.artipie.debian.misc.PublisherAsArchive;
+import com.artipie.asto.ext.PublisherAs;
+import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
 
 /**
@@ -79,23 +82,21 @@ public interface Package {
 
         @Override
         public CompletionStage<Void> add(final String item, final Key index) {
+            final byte[] bytes = item.getBytes(StandardCharsets.UTF_8);
             return this.asto.exists(index).thenCompose(
                 exists -> {
                     final CompletionStage<byte[]> res;
                     if (exists) {
                         res = this.asto.value(index).thenCompose(
-                            content -> new PublisherAsArchive(content).unpackedGz()
+                            content -> new PublisherAs(content).bytes()
                         ).thenApply(
-                            bytes -> Asto.compress(
-                                bytes,
-                                "\n\n".getBytes(StandardCharsets.UTF_8),
-                                item.getBytes(StandardCharsets.UTF_8)
+                            buffer -> Asto.decompressAppendCompress(
+                                buffer,
+                                String.format("\n\n%s", item).getBytes(StandardCharsets.UTF_8)
                             )
                         );
                     } else {
-                        res = CompletableFuture.completedFuture(
-                            Asto.compress(item.getBytes(StandardCharsets.UTF_8))
-                        );
+                        res = CompletableFuture.completedFuture(compress(bytes));
                     }
                     return res;
                 }
@@ -106,22 +107,51 @@ public interface Package {
 
         /**
          * Compress bytes in gz format.
-         * @param bytes Bytes to pack
+         * @param decompress Bytes to decompress
+         * @param append New bytes to append
          * @return Compressed bytes
          */
-        private static byte[] compress(final byte[]... bytes) {
+        @SuppressWarnings("PMD.AssignmentInOperand")
+        private static byte[] decompressAppendCompress(
+            final byte[] decompress, final byte[] append
+        ) {
             final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            try (GzipCompressorOutputStream gcos =
-                new GzipCompressorOutputStream(new BufferedOutputStream(baos))) {
-                for (final byte[] item : bytes) {
-                    gcos.write(item);
+            try (
+                GzipCompressorInputStream gcis = new GzipCompressorInputStream(
+                    new BufferedInputStream(new ByteArrayInputStream(decompress))
+                );
+                GzipCompressorOutputStream gcos =
+                    new GzipCompressorOutputStream(new BufferedOutputStream(baos))
+            ) {
+                // @checkstyle MagicNumberCheck (1 line)
+                final byte[] buf = new byte[1024];
+                int cnt;
+                while (-1 != (cnt = gcis.read(buf))) {
+                    gcos.write(buf, 0, cnt);
                 }
-            } catch (final IOException ex) {
-                throw new UncheckedIOException(ex);
+                gcos.write(append);
+            } catch (final IOException err) {
+                throw new UncheckedIOException(err);
             }
             return baos.toByteArray();
         }
 
+        /**
+         * Compress text for new Package index.
+         * @param bytes Bytes to compress
+         * @return Compressed bytes
+         */
+        private static byte[] compress(final byte[] bytes) {
+            final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            try (GzipCompressorOutputStream gcos =
+                new GzipCompressorOutputStream(new BufferedOutputStream(baos))
+                ) {
+                gcos.write(bytes);
+            } catch (final IOException err) {
+                throw new UncheckedIOException(err);
+            }
+            return baos.toByteArray();
+        }
     }
 
 }


### PR DESCRIPTION
Closes #49 
Do not pass decompressed Packages index files bytes.