### PR TITLE
#51 - extend debian interface

### DIFF
--- a/src/main/java/com/artipie/debian/Debian.java
+++ b/src/main/java/com/artipie/debian/Debian.java
@@ -46,25 +46,7 @@ public interface Debian {
     CompletionStage<Void> updatePackages(List<Key> debs, Key packages);
 
     /**
-     * Updates Release index file by adding information about Packages index file and generate
-     * corresponding Release.gpg file with the GPG signature. Find more information in the
-     * <a href="https://wiki.debian.org/DebianRepository/Format#A.22Release.22_files">documentation</a>.
-     * @param packages Packages index file to add info about
-     * @return Completion action
-     */
-    CompletionStage<Void> updateRelease(Key packages);
-
-    /**
-     * Updates InRelease index file by adding information about Packages index file and signs the
-     * file with the GPG signature. Find more information in the
-     * <a href="https://wiki.debian.org/DebianRepository/Format#A.22Release.22_files">documentation</a>.
-     * @param packages Packages index file to add info about
-     * @return Completion action
-     */
-    CompletionStage<Void> updateInRelease(Key packages);
-
-    /**
-     * Generates Release index file and corresponding Release.gpg file with the GPG
+     * Generates or updates Release index file and corresponding Release.gpg file with the GPG
      * signature. Find more information in the
      * <a href="https://wiki.debian.org/DebianRepository/Format#A.22Release.22_files">documentation</a>.
      * @return Completion action
@@ -72,7 +54,7 @@ public interface Debian {
     CompletionStage<Void> generateRelease();
 
     /**
-     * Generates InRelease index file and signs it with a GPG clearsign signature. Check
+     * Generates or updates InRelease index file and signs it with a GPG clearsign signature. Check
      * <a href="https://wiki.debian.org/DebianRepository/Format#A.22Release.22_files">documentation</a>
      * for more details.
      * @return Completion action
@@ -108,16 +90,6 @@ public interface Debian {
         @Override
         public CompletionStage<Void> updatePackages(final List<Key> debs, final Key packages) {
             throw new NotImplementedException("Not yet implemented");
-        }
-
-        @Override
-        public CompletionStage<Void> updateRelease(final Key packages) {
-            throw new NotImplementedException("Will be implemented letter");
-        }
-
-        @Override
-        public CompletionStage<Void> updateInRelease(final Key packages) {
-            throw new NotImplementedException("Will be implemented some day");
         }
 
         @Override

--- a/src/main/java/com/artipie/debian/Debian.java
+++ b/src/main/java/com/artipie/debian/Debian.java
@@ -46,7 +46,25 @@ public interface Debian {
     CompletionStage<Void> updatePackages(List<Key> debs, Key packages);
 
     /**
-     * Generates or updates Release index file and corresponding Release.gpg file with the GPG
+     * Updates Release index file by adding information about Packages index file and generate
+     * corresponding Release.gpg file with the GPG signature. Find more information in the
+     * <a href="https://wiki.debian.org/DebianRepository/Format#A.22Release.22_files">documentation</a>.
+     * @param packages Packages index file to add info about
+     * @return Completion action
+     */
+    CompletionStage<Void> updateRelease(Key packages);
+
+    /**
+     * Updates InRelease index file by adding information about Packages index file and signs the
+     * file with the GPG signature. Find more information in the
+     * <a href="https://wiki.debian.org/DebianRepository/Format#A.22Release.22_files">documentation</a>.
+     * @param packages Packages index file to add info about
+     * @return Completion action
+     */
+    CompletionStage<Void> updateInRelease(Key packages);
+
+    /**
+     * Generates Release index file and corresponding Release.gpg file with the GPG
      * signature. Find more information in the
      * <a href="https://wiki.debian.org/DebianRepository/Format#A.22Release.22_files">documentation</a>.
      * @return Completion action
@@ -54,7 +72,7 @@ public interface Debian {
     CompletionStage<Void> generateRelease();
 
     /**
-     * Generates or updates InRelease index file and signs it with a GPG clearsign signature. Check
+     * Generates InRelease index file and signs it with a GPG clearsign signature. Check
      * <a href="https://wiki.debian.org/DebianRepository/Format#A.22Release.22_files">documentation</a>
      * for more details.
      * @return Completion action
@@ -90,6 +108,16 @@ public interface Debian {
         @Override
         public CompletionStage<Void> updatePackages(final List<Key> debs, final Key packages) {
             throw new NotImplementedException("Not yet implemented");
+        }
+
+        @Override
+        public CompletionStage<Void> updateRelease(final Key packages) {
+            throw new NotImplementedException("Will be implemented letter");
+        }
+
+        @Override
+        public CompletionStage<Void> updateInRelease(final Key packages) {
+            throw new NotImplementedException("Will be implemented some day");
         }
 
         @Override

--- a/src/main/java/com/artipie/debian/Debian.java
+++ b/src/main/java/com/artipie/debian/Debian.java
@@ -50,34 +50,28 @@ public interface Debian {
      * corresponding Release.gpg file with the GPG signature. Find more information in the
      * <a href="https://wiki.debian.org/DebianRepository/Format#A.22Release.22_files">documentation</a>.
      * @param packages Packages index file to add info about
-     * @return Completion action
+     * @return Completion action with the key of the generated index
      */
-    CompletionStage<Void> updateRelease(Key packages);
-
-    /**
-     * Updates InRelease index file by adding information about Packages index file and signs the
-     * file with the GPG signature. Find more information in the
-     * <a href="https://wiki.debian.org/DebianRepository/Format#A.22Release.22_files">documentation</a>.
-     * @param packages Packages index file to add info about
-     * @return Completion action
-     */
-    CompletionStage<Void> updateInRelease(Key packages);
+    CompletionStage<Key> updateRelease(Key packages);
 
     /**
      * Generates Release index file and corresponding Release.gpg file with the GPG
      * signature. Find more information in the
      * <a href="https://wiki.debian.org/DebianRepository/Format#A.22Release.22_files">documentation</a>.
-     * @return Completion action
+     * @return Completion action with the key of the generated index
      */
-    CompletionStage<Void> generateRelease();
+    CompletionStage<Key> generateRelease();
 
     /**
-     * Generates InRelease index file and signs it with a GPG clearsign signature. Check
+     * Generates InRelease index file and signs it with a GPG clearsign signature. Process is based
+     * on provided Release index file, essentially this method signs provided Release index and
+     * generate corresponding file. Check
      * <a href="https://wiki.debian.org/DebianRepository/Format#A.22Release.22_files">documentation</a>
      * for more details.
+     * @param release Release index file key
      * @return Completion action
      */
-    CompletionStage<Void> generateInRelease();
+    CompletionStage<Void> generateInRelease(Key release);
 
     /**
      * Implementation of {@link Debian} from abstract storage.
@@ -111,22 +105,17 @@ public interface Debian {
         }
 
         @Override
-        public CompletionStage<Void> updateRelease(final Key packages) {
+        public CompletionStage<Key> updateRelease(final Key packages) {
             throw new NotImplementedException("Will be implemented letter");
         }
 
         @Override
-        public CompletionStage<Void> updateInRelease(final Key packages) {
-            throw new NotImplementedException("Will be implemented some day");
-        }
-
-        @Override
-        public CompletionStage<Void> generateRelease() {
+        public CompletionStage<Key> generateRelease() {
             throw new NotImplementedException("Not implemented yet");
         }
 
         @Override
-        public CompletionStage<Void> generateInRelease() {
+        public CompletionStage<Void> generateInRelease(final Key release) {
             throw new NotImplementedException("To be implemented");
         }
     }


### PR DESCRIPTION
Part of #51 
I've extended `Debian` with the methods to update info about provided `Packages` index file. This operation is faster than update info about all the `Packages` index files of the repo and as we know what `Packages` index file was changed it would be better to update info about this file only.