### PR TITLE
#51 - UnpackedContent: do not read whole file into memory

### DIFF
--- a/src/test/java/com/artipie/debian/misc/UnpackedContentTest.java
+++ b/src/test/java/com/artipie/debian/misc/UnpackedContentTest.java
@@ -25,6 +25,10 @@ package com.artipie.debian.misc;
 
 import com.artipie.asto.Content;
 import com.artipie.asto.test.TestResource;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
@@ -38,7 +42,7 @@ import org.junit.jupiter.api.Test;
 class UnpackedContentTest {
 
     @Test
-    void calcsSizeAndDigest() {
+    void calcsSizeAndDigest() throws IOException {
         MatcherAssert.assertThat(
             new UnpackedContent(
                 new Content.From(new TestResource("Packages.gz").asBytes())
@@ -48,6 +52,13 @@ class UnpackedContentTest {
                     2564L, "c1cfc96b4ca50645c57e10b65fcc89fd1b2b79eb495c9fa035613af7ff97dbff"
                 )
             )
+        );
+        final Path systemtemp = Paths.get(System.getProperty("java.io.tmpdir"));
+        MatcherAssert.assertThat(
+            "Temp dir for indexes removed",
+            Files.list(systemtemp)
+                .noneMatch(path -> path.getFileName().toString().startsWith("unpack")),
+            new IsEqual<>(true)
         );
     }
 


### PR DESCRIPTION
Part of #51 
Made `UnpackedContent` to write publisher into temp file and then unpack it to avoid memory consumption. 