### PR TITLE
#66 - created GzArchive

### DIFF
--- a/src/test/java/com/artipie/debian/DebianTest.java
+++ b/src/test/java/com/artipie/debian/DebianTest.java
@@ -173,7 +173,7 @@ class DebianTest {
         final String pckg = "pspp_1.2.0-3_amd64.deb";
         final Key.From key = new Key.From("some_repo", pckg);
         new TestResource(pckg).saveTo(this.storage, key);
-        new GzArchive(this.storage).pack(this.aglfn(), DebianTest.PACKAGES);
+        new GzArchive(this.storage).packAndSave(this.aglfn(), DebianTest.PACKAGES);
         this.debian.updatePackages(new ListOf<>(key), DebianTest.PACKAGES)
             .toCompletableFuture().join();
         MatcherAssert.assertThat(

--- a/src/test/java/com/artipie/debian/GzArchive.java
+++ b/src/test/java/com/artipie/debian/GzArchive.java
@@ -1,0 +1,111 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.debian;
+
+import com.artipie.asto.Content;
+import com.artipie.asto.Key;
+import com.artipie.asto.Storage;
+import com.artipie.asto.blocking.BlockingStorage;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+
+/**
+ * GzArchive: packs or unpacks.
+ * @since 0.4
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ */
+public final class GzArchive {
+
+    /**
+     * Abstract storage.
+     */
+    private final Storage asto;
+
+    /**
+     * Ctor.
+     * @param asto Abstract storage
+     */
+    public GzArchive(final Storage asto) {
+        this.asto = asto;
+    }
+
+    /**
+     * Compress provided bytes in gz format and adds item to storage by provided key.
+     * @param bytes Bytes to pack
+     * @param key Storage key
+     */
+    public void pack(final byte[] bytes, final Key key) {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (GzipCompressorOutputStream gcos =
+            new GzipCompressorOutputStream(new BufferedOutputStream(baos))) {
+            gcos.write(bytes);
+        } catch (final IOException err) {
+            throw new UncheckedIOException(err);
+        }
+        this.asto.save(key, new Content.From(baos.toByteArray())).join();
+    }
+
+    /**
+     * Compress provided string in gz format and adds item to storage by provided key.
+     * @param content String to pack
+     * @param key Storage key
+     */
+    public void pack(final String content, final Key key) {
+        this.pack(content.getBytes(StandardCharsets.UTF_8), key);
+    }
+
+    /**
+     * Unpacks storage item and returns unpacked content as string.
+     * @param key Storage item
+     * @return Unpacked string
+     * @checkstyle MagicNumberCheck (15 lines)
+     */
+    @SuppressWarnings("PMD.AssignmentInOperand")
+    public String unpack(final Key key) {
+        try (
+            GzipCompressorInputStream gcis = new GzipCompressorInputStream(
+                new BufferedInputStream(
+                    new ByteArrayInputStream(new BlockingStorage(this.asto).value(key))
+                )
+            )
+        ) {
+            final ByteArrayOutputStream out = new ByteArrayOutputStream();
+            final byte[] buf = new byte[1024];
+            int cnt;
+            while (-1 != (cnt = gcis.read(buf))) {
+                out.write(buf, 0, cnt);
+            }
+            return out.toString();
+        } catch (final IOException err) {
+            throw new UncheckedIOException(err);
+        }
+    }
+}

--- a/src/test/java/com/artipie/debian/GzArchive.java
+++ b/src/test/java/com/artipie/debian/GzArchive.java
@@ -62,7 +62,7 @@ public final class GzArchive {
      * @param bytes Bytes to pack
      * @param key Storage key
      */
-    public void pack(final byte[] bytes, final Key key) {
+    public void packAndSave(final byte[] bytes, final Key key) {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try (GzipCompressorOutputStream gcos =
             new GzipCompressorOutputStream(new BufferedOutputStream(baos))) {
@@ -78,8 +78,8 @@ public final class GzArchive {
      * @param content String to pack
      * @param key Storage key
      */
-    public void pack(final String content, final Key key) {
-        this.pack(content.getBytes(StandardCharsets.UTF_8), key);
+    public void packAndSave(final String content, final Key key) {
+        this.packAndSave(content.getBytes(StandardCharsets.UTF_8), key);
     }
 
     /**

--- a/src/test/java/com/artipie/debian/metadata/ReleaseAstoTest.java
+++ b/src/test/java/com/artipie/debian/metadata/ReleaseAstoTest.java
@@ -32,13 +32,11 @@ import com.artipie.asto.ext.PublisherAs;
 import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.asto.test.TestResource;
 import com.artipie.debian.Config;
+import com.artipie.debian.GzArchive;
 import com.artipie.http.slice.KeyFromPath;
-import java.io.BufferedOutputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
-import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
 import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -154,7 +152,7 @@ class ReleaseAstoTest {
             new Key.From("dists/my-deb/main/binary-amd64/Packages.gz"), Content.EMPTY
         ).join();
         final Key key = new Key.From("dists/my-deb/main/binary-intel/Packages.gz");
-        this.asto.save(key, new Content.From(this.packed("abc123".getBytes()))).join();
+        new GzArchive(this.asto).pack("abc123", key);
         final ListOf<String> content = new ListOf<>(
             "Codename: my-deb",
             "Architectures: amd64 intel",
@@ -198,7 +196,7 @@ class ReleaseAstoTest {
             new Key.From("dists/my-repo/main/binary-amd64/Packages.gz"), Content.EMPTY
         ).join();
         final Key key = new Key.From("dists/my-repo/main/binary-intel/Packages.gz");
-        this.asto.save(key, new Content.From(this.packed("xyz".getBytes()))).join();
+        new GzArchive(this.asto).pack("xyz", key);
         final ListOf<String> content = new ListOf<>(
             "Codename: my-repo",
             "Architectures: amd64 intel",
@@ -240,7 +238,7 @@ class ReleaseAstoTest {
             new Key.From("dists/deb-test/main/binary-amd64/Packages.gz"), Content.EMPTY
         ).join();
         final Key key = new Key.From("dists/deb-test/main/binary-intel/Packages.gz");
-        this.asto.save(key, new Content.From(this.packed("098".getBytes()))).join();
+        new GzArchive(this.asto).pack("098", key);
         final ListOf<String> content = new ListOf<>(
             "Codename: deb-test",
             "Architectures: amd64 intel",
@@ -303,15 +301,6 @@ class ReleaseAstoTest {
             ).gpgSignatureKey(),
             new IsEqual<>(new Key.From("dists/deb-repo/Release.gpg"))
         );
-    }
-
-    private byte[] packed(final byte[] bytes) throws IOException {
-        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        try (GzipCompressorOutputStream gcos =
-            new GzipCompressorOutputStream(new BufferedOutputStream(baos))) {
-            gcos.write(bytes);
-        }
-        return baos.toByteArray();
     }
 
     private Config config(final boolean gpg, final String name, final YamlMappingBuilder yaml) {

--- a/src/test/java/com/artipie/debian/metadata/ReleaseAstoTest.java
+++ b/src/test/java/com/artipie/debian/metadata/ReleaseAstoTest.java
@@ -152,7 +152,7 @@ class ReleaseAstoTest {
             new Key.From("dists/my-deb/main/binary-amd64/Packages.gz"), Content.EMPTY
         ).join();
         final Key key = new Key.From("dists/my-deb/main/binary-intel/Packages.gz");
-        new GzArchive(this.asto).pack("abc123", key);
+        new GzArchive(this.asto).packAndSave("abc123", key);
         final ListOf<String> content = new ListOf<>(
             "Codename: my-deb",
             "Architectures: amd64 intel",
@@ -196,7 +196,7 @@ class ReleaseAstoTest {
             new Key.From("dists/my-repo/main/binary-amd64/Packages.gz"), Content.EMPTY
         ).join();
         final Key key = new Key.From("dists/my-repo/main/binary-intel/Packages.gz");
-        new GzArchive(this.asto).pack("xyz", key);
+        new GzArchive(this.asto).packAndSave("xyz", key);
         final ListOf<String> content = new ListOf<>(
             "Codename: my-repo",
             "Architectures: amd64 intel",
@@ -238,7 +238,7 @@ class ReleaseAstoTest {
             new Key.From("dists/deb-test/main/binary-amd64/Packages.gz"), Content.EMPTY
         ).join();
         final Key key = new Key.From("dists/deb-test/main/binary-intel/Packages.gz");
-        new GzArchive(this.asto).pack("098", key);
+        new GzArchive(this.asto).packAndSave("098", key);
         final ListOf<String> content = new ListOf<>(
             "Codename: deb-test",
             "Architectures: amd64 intel",


### PR DESCRIPTION
Closes #66 
Created `GzArchive` in test scope to pack/unpack `.gz` and used it in tests, removed all duplications.