### PR TITLE
System dependent line separator in gpg clearsign

### DIFF
--- a/src/main/java/com/artipie/debian/metadata/Release.java
+++ b/src/main/java/com/artipie/debian/metadata/Release.java
@@ -109,7 +109,7 @@ public interface Release {
             return this.checksums()
                 .thenApply(
                     checksums -> String.join(
-                        "\n",
+                        System.lineSeparator(),
                         String.format("Codename: %s", this.config.codename()),
                         String.format("Architectures: %s", String.join(" ", this.config.archs())),
                         String.format("Components: %s", String.join(" ", this.config.components())),
@@ -256,14 +256,18 @@ public interface Release {
          */
         private static String addReplace(final String origin, final String key, final String repl) {
             final String res;
-            if (origin.contains(String.format("%s\n", key)) || origin.endsWith(key)) {
+            if (origin.contains(String.format("%s%s", key, System.lineSeparator()))
+                || origin.endsWith(key)) {
                 res = origin.replaceAll(
-                    String.format(" .* %s(\n|$)", Pattern.quote(key)), String.format("%s\n", repl)
+                    String.format(" .* %s(%s|$)", Pattern.quote(key), System.lineSeparator()),
+                    String.format("%s%s", repl, System.lineSeparator())
                 );
             } else {
-                res = String.format("%s\n%s", origin, repl);
+                res = String.format("%s%s%s", origin, System.lineSeparator(), repl);
             }
-            return res.replaceAll("\n+", "\n");
+            return res.replaceAll(
+                String.format("[%s]+", System.lineSeparator()), System.lineSeparator()
+            );
         }
     }
 }

--- a/src/main/java/com/artipie/debian/misc/GpgClearsign.java
+++ b/src/main/java/com/artipie/debian/misc/GpgClearsign.java
@@ -101,8 +101,7 @@ public final class GpgClearsign {
                 if (ahead != -1) {
                     do {
                         ahead = GpgClearsign.readInputLine(line, ahead, input);
-                        sgen.update((byte) '\r');
-                        sgen.update((byte) '\n');
+                        sgen.update(System.lineSeparator().getBytes());
                         GpgClearsign.processLine(armored, sgen, line.toByteArray());
                     }
                     while (ahead != -1);

--- a/src/main/java/com/artipie/debian/misc/GpgClearsign.java
+++ b/src/main/java/com/artipie/debian/misc/GpgClearsign.java
@@ -31,7 +31,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
 import java.security.Security;
 import java.util.Iterator;
 import org.bouncycastle.bcpg.ArmoredOutputStream;
@@ -102,7 +101,8 @@ public final class GpgClearsign {
                 if (ahead != -1) {
                     do {
                         ahead = GpgClearsign.readInputLine(line, ahead, input);
-                        sgen.update(System.lineSeparator().getBytes(StandardCharsets.US_ASCII));
+                        sgen.update((byte) '\r');
+                        sgen.update((byte) '\n');
                         GpgClearsign.processLine(armored, sgen, line.toByteArray());
                     }
                     while (ahead != -1);

--- a/src/main/java/com/artipie/debian/misc/GpgClearsign.java
+++ b/src/main/java/com/artipie/debian/misc/GpgClearsign.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.security.Security;
 import java.util.Iterator;
 import org.bouncycastle.bcpg.ArmoredOutputStream;
@@ -101,7 +102,7 @@ public final class GpgClearsign {
                 if (ahead != -1) {
                     do {
                         ahead = GpgClearsign.readInputLine(line, ahead, input);
-                        sgen.update(System.lineSeparator().getBytes());
+                        sgen.update(System.lineSeparator().getBytes(StandardCharsets.US_ASCII));
                         GpgClearsign.processLine(armored, sgen, line.toByteArray());
                     }
                     while (ahead != -1);

--- a/src/test/java/com/artipie/debian/metadata/InReleaseAstoTest.java
+++ b/src/test/java/com/artipie/debian/metadata/InReleaseAstoTest.java
@@ -83,7 +83,9 @@ class InReleaseAstoTest {
                     new StringContains(new String(new TestResource("Release").asBytes())),
                     new StringContains("-----BEGIN PGP SIGNED MESSAGE-----"),
                     new StringContains("Hash: SHA256"),
-                    new StringContains("-----BEGIN PGP SIGNATURE-----"),
+                    new StringContains(
+                        String.format("%s-----BEGIN PGP SIGNATURE-----", System.lineSeparator())
+                    ),
                     new StringContains("-----END PGP SIGNATURE-----")
                 )
             )

--- a/src/test/java/com/artipie/debian/metadata/ReleaseAstoTest.java
+++ b/src/test/java/com/artipie/debian/metadata/ReleaseAstoTest.java
@@ -163,7 +163,9 @@ class ReleaseAstoTest {
         );
         this.asto.save(
             new Key.From("dists/my-deb/Release"),
-            new Content.From(String.join("\n", content).getBytes(StandardCharsets.UTF_8))
+            new Content.From(
+                String.join(System.lineSeparator(), content).getBytes(StandardCharsets.UTF_8)
+            )
         ).join();
         final Release release = new Release.Asto(
             this.asto,
@@ -208,7 +210,8 @@ class ReleaseAstoTest {
         );
         this.asto.save(
             new Key.From("dists/my-repo/Release"),
-            new Content.From(String.join("\n", content).getBytes(StandardCharsets.UTF_8))
+            new Content.From(String.join(System.lineSeparator(), content)
+                .getBytes(StandardCharsets.UTF_8))
         ).join();
         new Release.Asto(
             this.asto,
@@ -250,7 +253,8 @@ class ReleaseAstoTest {
         );
         this.asto.save(
             new Key.From("dists/deb-test/Release"),
-            new Content.From(String.join("\n", content).getBytes(StandardCharsets.UTF_8))
+            new Content.From(String.join(System.lineSeparator(), content)
+                .getBytes(StandardCharsets.UTF_8))
         ).join();
         new Release.Asto(
             this.asto,
@@ -264,7 +268,7 @@ class ReleaseAstoTest {
             "Release file updated",
             new PublisherAs(this.asto.value(new KeyFromPath("dists/deb-test/Release")).join())
                 .asciiString().toCompletableFuture().join(),
-            new IsEqual<>(String.join("\n", content))
+            new IsEqual<>(String.join(System.lineSeparator(), content))
         );
         MatcherAssert.assertThat(
             "Gpg file was created if necessary",

--- a/src/test/java/com/artipie/debian/metadata/ReleaseAstoTest.java
+++ b/src/test/java/com/artipie/debian/metadata/ReleaseAstoTest.java
@@ -210,8 +210,9 @@ class ReleaseAstoTest {
         );
         this.asto.save(
             new Key.From("dists/my-repo/Release"),
-            new Content.From(String.join(System.lineSeparator(), content)
-                .getBytes(StandardCharsets.UTF_8))
+            new Content.From(
+                String.join(System.lineSeparator(), content).getBytes(StandardCharsets.UTF_8)
+            )
         ).join();
         new Release.Asto(
             this.asto,
@@ -225,7 +226,7 @@ class ReleaseAstoTest {
             "Release file was updated",
             new PublisherAs(this.asto.value(new KeyFromPath("dists/my-repo/Release")).join())
                 .asciiString().toCompletableFuture().join(),
-            new IsEqual<>(String.join("\n", content))
+            new IsEqual<>(String.join(System.lineSeparator(), content))
         );
         MatcherAssert.assertThat(
             "Gpg file was created if necessary",
@@ -253,8 +254,9 @@ class ReleaseAstoTest {
         );
         this.asto.save(
             new Key.From("dists/deb-test/Release"),
-            new Content.From(String.join(System.lineSeparator(), content)
-                .getBytes(StandardCharsets.UTF_8))
+            new Content.From(
+                String.join(System.lineSeparator(), content).getBytes(StandardCharsets.UTF_8)
+            )
         ).join();
         new Release.Asto(
             this.asto,

--- a/src/test/java/com/artipie/debian/misc/GpgClearsignTest.java
+++ b/src/test/java/com/artipie/debian/misc/GpgClearsignTest.java
@@ -53,7 +53,9 @@ class GpgClearsignTest {
                     new StringContains(new String(release)),
                     new StringContains("-----BEGIN PGP SIGNED MESSAGE-----"),
                     new StringContains("Hash: SHA256"),
-                    new StringContains("-----BEGIN PGP SIGNATURE-----"),
+                    new StringContains(
+                        String.format("%s-----BEGIN PGP SIGNATURE-----", System.lineSeparator())
+                    ),
                     new StringContains("-----END PGP SIGNATURE-----")
                 )
             )


### PR DESCRIPTION
Closes #80 
Used system dependent line separator in `GpgClearsign#signedContent`, updated tests.