### PR TITLE
New line before signature in InRelease

### DIFF
--- a/src/test/java/com/artipie/debian/metadata/InReleaseAstoTest.java
+++ b/src/test/java/com/artipie/debian/metadata/InReleaseAstoTest.java
@@ -83,7 +83,7 @@ class InReleaseAstoTest {
                     new StringContains(new String(new TestResource("Release").asBytes())),
                     new StringContains("-----BEGIN PGP SIGNED MESSAGE-----"),
                     new StringContains("Hash: SHA256"),
-                    new StringContains("-----BEGIN PGP SIGNATURE-----"),
+                    new StringContains("\n-----BEGIN PGP SIGNATURE-----"),
                     new StringContains("-----END PGP SIGNATURE-----")
                 )
             )


### PR DESCRIPTION
For #80 
Fixed bug with no line break in `InRelease` before gpg signature.