### PR TITLE
Do not add duplicated info into Packages index

### DIFF
--- a/src/main/java/com/artipie/debian/metadata/ControlField.java
+++ b/src/main/java/com/artipie/debian/metadata/ControlField.java
@@ -118,4 +118,18 @@ public interface ControlField {
             super("Version");
         }
     }
+
+    /**
+     * Filename.
+     * @since 0.5
+     */
+    final class Filename extends ByName {
+
+        /**
+         * Ctor.
+         */
+        public Filename() {
+            super("Filename");
+        }
+    }
 }

--- a/src/test/java/com/artipie/debian/metadata/UniquePackageTest.java
+++ b/src/test/java/com/artipie/debian/metadata/UniquePackageTest.java
@@ -35,7 +35,6 @@ import java.nio.file.Paths;
 import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
-import org.hamcrest.text.StringContainsInOrder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -44,6 +43,7 @@ import org.junit.jupiter.api.Test;
  * @since 0.5
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyMethods"})
 class UniquePackageTest {
 
     /**
@@ -72,11 +72,126 @@ class UniquePackageTest {
         MatcherAssert.assertThat(
             "Packages index has info about 3 packages",
             new GzArchive(this.asto).unpack(new Key.From(UniquePackageTest.KEY)),
-            new StringContainsInOrder(
-                new ListOf<String>(
-                    new GzArchive(temp).unpack(new Key.From(UniquePackageTest.KEY)),
+            new IsEqual<>(
+                String.join(
                     "\n\n",
+                    new GzArchive(temp).unpack(new Key.From(UniquePackageTest.KEY)),
                     this.abcPackageInfo()
+                )
+            )
+        );
+        this.verifyThatTempDirIsCleanedUp();
+    }
+
+    @Test
+    void replacesOneExistingPackage() throws IOException {
+        new GzArchive(this.asto).packAndSave(
+            this.abcPackageInfo()
+                .replace("MD5sum: e99a18c428cb38d5f260853678922e03", "MD5sum: abc123"),
+            new Key.From(UniquePackageTest.KEY)
+        );
+        new UniquePackage(this.asto)
+            .add(new ListOf<>(this.abcPackageInfo()), new Key.From(UniquePackageTest.KEY))
+            .toCompletableFuture().join();
+        MatcherAssert.assertThat(
+            "Packages index has info about 1 package",
+            new GzArchive(this.asto).unpack(new Key.From(UniquePackageTest.KEY)),
+            new IsEqual<>(this.abcPackageInfo())
+        );
+        this.verifyThatTempDirIsCleanedUp();
+    }
+
+    @Test
+    void doesNotReplacePackageWithAnotherVersion() throws IOException {
+        final String second = this.abcPackageInfo().replace("Version: 0.1", "Version: 0.2");
+        new GzArchive(this.asto).packAndSave(second, new Key.From(UniquePackageTest.KEY));
+        new UniquePackage(this.asto)
+            .add(new ListOf<>(this.abcPackageInfo()), new Key.From(UniquePackageTest.KEY))
+            .toCompletableFuture().join();
+        MatcherAssert.assertThat(
+            "Packages index has info about 2 packages",
+            new GzArchive(this.asto).unpack(new Key.From(UniquePackageTest.KEY)),
+            new IsEqual<>(String.join("\n\n", second, this.abcPackageInfo()))
+        );
+        this.verifyThatTempDirIsCleanedUp();
+    }
+
+    @Test
+    void replacesFirstDuplicatedPackage() throws IOException {
+        new GzArchive(this.asto).packAndSave(
+            String.join(
+                "\n\n",
+                this.zeroPackageInfo().replace("Installed-Size: 0", "Installed-Size: 1"),
+                this.xyzPackageInfo()
+            ),
+            new Key.From(UniquePackageTest.KEY)
+        );
+        new UniquePackage(this.asto)
+            .add(
+                new ListOf<>(this.zeroPackageInfo(), this.abcPackageInfo()),
+                new Key.From(UniquePackageTest.KEY)
+            ).toCompletableFuture().join();
+        MatcherAssert.assertThat(
+            "Packages index has info about 3 packages",
+            new GzArchive(this.asto).unpack(new Key.From(UniquePackageTest.KEY)),
+            new IsEqual<>(
+                String.join(
+                    "\n\n", this.xyzPackageInfo(), this.zeroPackageInfo(), this.abcPackageInfo()
+                )
+            )
+        );
+        this.verifyThatTempDirIsCleanedUp();
+    }
+
+    @Test
+    void replacesLastDuplicatedPackage() throws IOException {
+        new GzArchive(this.asto).packAndSave(
+            String.join(
+                "\n\n",
+                this.abcPackageInfo(),
+                this.zeroPackageInfo().replace("Installed-Size: 0", "Installed-Size: 1")
+            ),
+            new Key.From(UniquePackageTest.KEY)
+        );
+        new UniquePackage(this.asto)
+            .add(
+                new ListOf<>(this.xyzPackageInfo(), this.zeroPackageInfo()),
+                new Key.From(UniquePackageTest.KEY)
+            ).toCompletableFuture().join();
+        MatcherAssert.assertThat(
+            "Packages index has info about 3 packages",
+            new GzArchive(this.asto).unpack(new Key.From(UniquePackageTest.KEY)),
+            new IsEqual<>(
+                String.join(
+                    "\n\n", this.abcPackageInfo(), this.xyzPackageInfo(), this.zeroPackageInfo()
+                )
+            )
+        );
+        this.verifyThatTempDirIsCleanedUp();
+    }
+
+    @Test
+    void replacesMiddleDuplicatedPackage() throws IOException {
+        new GzArchive(this.asto).packAndSave(
+            String.join(
+                "\n\n",
+                this.abcPackageInfo(),
+                this.zeroPackageInfo().replace("Installed-Size: 0", "Installed-Size: 1"),
+                this.xyzPackageInfo()
+            ),
+            new Key.From(UniquePackageTest.KEY)
+        );
+        new UniquePackage(this.asto)
+            .add(
+                new ListOf<>(this.zeroPackageInfo()),
+                new Key.From(UniquePackageTest.KEY)
+            ).toCompletableFuture().join();
+        MatcherAssert.assertThat(
+            "Packages index has info about 3 packages",
+            new GzArchive(this.asto).unpack(new Key.From(UniquePackageTest.KEY)),
+            new IsEqual<>(
+                String.join(
+                    "\n\n", this.abcPackageInfo(), this.xyzPackageInfo(), this.zeroPackageInfo()
                 )
             )
         );
@@ -105,6 +220,36 @@ class UniquePackageTest {
             "Filename: some/debian/package.deb",
             "Size: 23",
             "MD5sum: e99a18c428cb38d5f260853678922e03"
+        );
+    }
+
+    private String xyzPackageInfo() {
+        return String.join(
+            "\n",
+            "Package: xyz",
+            "Version: 0.6",
+            "Architecture: amd64",
+            "Maintainer: Blue Sky",
+            "Installed-Size: 131",
+            "Section: Un-Existing",
+            "Filename: some/not/existing/package.deb",
+            "Size: 45",
+            "MD5sum: e99a18c428cb38d5f260883678922e03"
+        );
+    }
+
+    private String zeroPackageInfo() {
+        return String.join(
+            "\n",
+            "Package: zero",
+            "Version: 0.0",
+            "Architecture: all",
+            "Maintainer: Zero division",
+            "Installed-Size: 0",
+            "Section: Zero",
+            "Filename: zero/package.deb",
+            "Size: 0",
+            "MD5sum: 0000"
         );
     }
 

--- a/src/test/java/com/artipie/debian/metadata/UniquePackageTest.java
+++ b/src/test/java/com/artipie/debian/metadata/UniquePackageTest.java
@@ -47,9 +47,14 @@ import org.junit.jupiter.api.Test;
 class UniquePackageTest {
 
     /**
+     * Packages file index name.
+     */
+    private static final String PCKG = "Packages.gz";
+
+    /**
      * Packages file index key.
      */
-    private static final String KEY = "Packages.gz";
+    private static final Key.From KEY = new Key.From(UniquePackageTest.PCKG);
 
     /**
      * Test storage.
@@ -63,19 +68,19 @@ class UniquePackageTest {
 
     @Test
     void appendsNewRecord() throws IOException {
-        new TestResource(UniquePackageTest.KEY).saveTo(this.asto);
+        new TestResource(UniquePackageTest.PCKG).saveTo(this.asto);
         new UniquePackage(this.asto)
-            .add(new ListOf<>(this.abcPackageInfo()), new Key.From(UniquePackageTest.KEY))
+            .add(new ListOf<>(this.abcPackageInfo()), UniquePackageTest.KEY)
             .toCompletableFuture().join();
         final Storage temp = new InMemoryStorage();
-        new TestResource(UniquePackageTest.KEY).saveTo(temp);
+        new TestResource(UniquePackageTest.PCKG).saveTo(temp);
         MatcherAssert.assertThat(
             "Packages index has info about 3 packages",
-            new GzArchive(this.asto).unpack(new Key.From(UniquePackageTest.KEY)),
+            new GzArchive(this.asto).unpack(UniquePackageTest.KEY),
             new IsEqual<>(
                 String.join(
                     "\n\n",
-                    new GzArchive(temp).unpack(new Key.From(UniquePackageTest.KEY)),
+                    new GzArchive(temp).unpack(UniquePackageTest.KEY),
                     this.abcPackageInfo()
                 )
             )
@@ -88,14 +93,14 @@ class UniquePackageTest {
         new GzArchive(this.asto).packAndSave(
             this.abcPackageInfo()
                 .replace("MD5sum: e99a18c428cb38d5f260853678922e03", "MD5sum: abc123"),
-            new Key.From(UniquePackageTest.KEY)
+            UniquePackageTest.KEY
         );
         new UniquePackage(this.asto)
-            .add(new ListOf<>(this.abcPackageInfo()), new Key.From(UniquePackageTest.KEY))
+            .add(new ListOf<>(this.abcPackageInfo()), UniquePackageTest.KEY)
             .toCompletableFuture().join();
         MatcherAssert.assertThat(
             "Packages index has info about 1 package",
-            new GzArchive(this.asto).unpack(new Key.From(UniquePackageTest.KEY)),
+            new GzArchive(this.asto).unpack(UniquePackageTest.KEY),
             new IsEqual<>(this.abcPackageInfo())
         );
         this.verifyThatTempDirIsCleanedUp();
@@ -104,13 +109,13 @@ class UniquePackageTest {
     @Test
     void doesNotReplacePackageWithAnotherVersion() throws IOException {
         final String second = this.abcPackageInfo().replace("Version: 0.1", "Version: 0.2");
-        new GzArchive(this.asto).packAndSave(second, new Key.From(UniquePackageTest.KEY));
+        new GzArchive(this.asto).packAndSave(second, UniquePackageTest.KEY);
         new UniquePackage(this.asto)
-            .add(new ListOf<>(this.abcPackageInfo()), new Key.From(UniquePackageTest.KEY))
+            .add(new ListOf<>(this.abcPackageInfo()), UniquePackageTest.KEY)
             .toCompletableFuture().join();
         MatcherAssert.assertThat(
             "Packages index has info about 2 packages",
-            new GzArchive(this.asto).unpack(new Key.From(UniquePackageTest.KEY)),
+            new GzArchive(this.asto).unpack(UniquePackageTest.KEY),
             new IsEqual<>(String.join("\n\n", second, this.abcPackageInfo()))
         );
         this.verifyThatTempDirIsCleanedUp();
@@ -124,16 +129,16 @@ class UniquePackageTest {
                 this.zeroPackageInfo().replace("Installed-Size: 0", "Installed-Size: 1"),
                 this.xyzPackageInfo()
             ),
-            new Key.From(UniquePackageTest.KEY)
+            UniquePackageTest.KEY
         );
         new UniquePackage(this.asto)
             .add(
                 new ListOf<>(this.zeroPackageInfo(), this.abcPackageInfo()),
-                new Key.From(UniquePackageTest.KEY)
+                UniquePackageTest.KEY
             ).toCompletableFuture().join();
         MatcherAssert.assertThat(
             "Packages index has info about 3 packages",
-            new GzArchive(this.asto).unpack(new Key.From(UniquePackageTest.KEY)),
+            new GzArchive(this.asto).unpack(UniquePackageTest.KEY),
             new IsEqual<>(
                 String.join(
                     "\n\n", this.xyzPackageInfo(), this.zeroPackageInfo(), this.abcPackageInfo()
@@ -149,18 +154,18 @@ class UniquePackageTest {
             String.join(
                 "\n\n",
                 this.abcPackageInfo(),
-                this.zeroPackageInfo().replace("Installed-Size: 0", "Installed-Size: 1")
+                this.zeroPackageInfo().replace("Architecture: all", "Architecture: amd64")
             ),
-            new Key.From(UniquePackageTest.KEY)
+            UniquePackageTest.KEY
         );
         new UniquePackage(this.asto)
             .add(
                 new ListOf<>(this.xyzPackageInfo(), this.zeroPackageInfo()),
-                new Key.From(UniquePackageTest.KEY)
+                UniquePackageTest.KEY
             ).toCompletableFuture().join();
         MatcherAssert.assertThat(
             "Packages index has info about 3 packages",
-            new GzArchive(this.asto).unpack(new Key.From(UniquePackageTest.KEY)),
+            new GzArchive(this.asto).unpack(UniquePackageTest.KEY),
             new IsEqual<>(
                 String.join(
                     "\n\n", this.abcPackageInfo(), this.xyzPackageInfo(), this.zeroPackageInfo()
@@ -176,19 +181,19 @@ class UniquePackageTest {
             String.join(
                 "\n\n",
                 this.abcPackageInfo(),
-                this.zeroPackageInfo().replace("Installed-Size: 0", "Installed-Size: 1"),
+                this.zeroPackageInfo().replace("Section: Zero", "Section: Zero-One-One"),
                 this.xyzPackageInfo()
             ),
-            new Key.From(UniquePackageTest.KEY)
+            UniquePackageTest.KEY
         );
         new UniquePackage(this.asto)
             .add(
                 new ListOf<>(this.zeroPackageInfo()),
-                new Key.From(UniquePackageTest.KEY)
+                UniquePackageTest.KEY
             ).toCompletableFuture().join();
         MatcherAssert.assertThat(
             "Packages index has info about 3 packages",
-            new GzArchive(this.asto).unpack(new Key.From(UniquePackageTest.KEY)),
+            new GzArchive(this.asto).unpack(UniquePackageTest.KEY),
             new IsEqual<>(
                 String.join(
                     "\n\n", this.abcPackageInfo(), this.xyzPackageInfo(), this.zeroPackageInfo()


### PR DESCRIPTION
Part of #74 
Implemented logic and added tests not to add duplicated info into `Packages` index. 
Will extract duplicated `if-else` statement into separate method is the next PR, also it will be necessary to remove old duplicated `.deb` packages with the help of the list returned by `decompressAppendCompress` method.