### PR TITLE
Added `RosUnpackedContent` - unpacking with reactive output stream

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,11 @@ SOFTWARE.
   </properties>
   <dependencies>
     <dependency>
+      <groupId>org.cqfn</groupId>
+      <artifactId>rio</artifactId>
+      <version>0.3</version>
+    </dependency>
+    <dependency>
       <groupId>com.jcabi</groupId>
       <artifactId>jcabi-log</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>asto</artifactId>
-      <version>0.33.1</version>
+      <version>0.34</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>

--- a/src/main/java/com/artipie/debian/metadata/Release.java
+++ b/src/main/java/com/artipie/debian/metadata/Release.java
@@ -33,7 +33,7 @@ import com.artipie.asto.rx.RxStorageWrapper;
 import com.artipie.debian.Config;
 import com.artipie.debian.GpgConfig;
 import com.artipie.debian.misc.GpgClearsign;
-import com.artipie.debian.misc.UnpackedContent;
+import com.artipie.debian.misc.RosUnpackedContent;
 import hu.akarnokd.rxjava2.interop.SingleInterop;
 import io.reactivex.Observable;
 import java.nio.charset.StandardCharsets;
@@ -228,7 +228,7 @@ public interface Release {
                 content -> new ContentDigest(content, Digests.SHA256).hex()
             ).thenCompose(
                 hex -> this.asto.value(pkg).thenCompose(
-                    content -> new UnpackedContent(content).sizeAndDigest().thenApply(
+                    content -> new RosUnpackedContent(content).sizeAndDigest().thenApply(
                         data -> new ImmutablePair<>(
                             String.format(
                                 " %s %d %s", hex,

--- a/src/main/java/com/artipie/debian/misc/RosUnpackedContent.java
+++ b/src/main/java/com/artipie/debian/misc/RosUnpackedContent.java
@@ -1,0 +1,93 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.debian.misc;
+
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.CompletionStage;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.cqfn.rio.WriteGreed;
+import org.cqfn.rio.stream.ReactiveOutputStream;
+import org.reactivestreams.Publisher;
+
+/**
+ * Unpacked content that uses {@link ReactiveOutputStream}.
+ * @since 0.5
+ */
+public final class RosUnpackedContent {
+
+    /**
+     * Publisher.
+     */
+    private final Publisher<ByteBuffer> content;
+
+    /**
+     * Ctor.
+     * @param content Content
+     */
+    public RosUnpackedContent(final Publisher<ByteBuffer> content) {
+        this.content = content;
+    }
+
+    /**
+     * Calculates size and digest of the gz packed content.
+     * @return Size and digest
+     */
+    @SuppressWarnings("PMD.AssignmentInOperand")
+    public CompletionStage<Pair<Long, String>> sizeAndDigest() {
+        try (
+            PipedInputStream in = new PipedInputStream();
+            PipedOutputStream out = new PipedOutputStream(in)
+        ) {
+            final MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            final CompletionStage<Void> ros =
+                new ReactiveOutputStream(out).write(this.content, WriteGreed.SYSTEM);
+            long size = 0;
+            try (GzipCompressorInputStream gcis = new GzipCompressorInputStream(in)) {
+                // @checkstyle MagicNumberCheck (1 line)
+                final byte[] buf = new byte[1024];
+                int cnt;
+                while (-1 != (cnt = gcis.read(buf))) {
+                    digest.update(buf, 0, cnt);
+                    size = size + cnt;
+                }
+                final ImmutablePair<Long, String> pair =
+                    new ImmutablePair<>(size, Hex.encodeHexString(digest.digest()));
+                return ros.thenApply(nothing -> pair);
+            }
+        } catch (final NoSuchAlgorithmException err) {
+            throw new IllegalStateException(err);
+        } catch (final IOException err) {
+            throw new UncheckedIOException(err);
+        }
+    }
+}

--- a/src/main/java/com/artipie/debian/misc/RosUnpackedContent.java
+++ b/src/main/java/com/artipie/debian/misc/RosUnpackedContent.java
@@ -41,7 +41,7 @@ import org.reactivestreams.Publisher;
 
 /**
  * Unpacked content that uses {@link ReactiveOutputStream}.
- * @since 0.5
+ * @since 0.6
  */
 public final class RosUnpackedContent {
 

--- a/src/test/java/com/artipie/debian/misc/RosUnpackedContentTest.java
+++ b/src/test/java/com/artipie/debian/misc/RosUnpackedContentTest.java
@@ -1,0 +1,54 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.debian.misc;
+
+import com.artipie.asto.Content;
+import com.artipie.asto.test.TestResource;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for {@link RosUnpackedContent}.
+ * @since 0.5
+ */
+class RosUnpackedContentTest {
+
+    @Test
+    void calcsSizeAndDigest() {
+        MatcherAssert.assertThat(
+            new RosUnpackedContent(
+                new Content.From(new TestResource("Packages.gz").asBytes())
+            ).sizeAndDigest().toCompletableFuture().join(),
+            new IsEqual<>(
+                new ImmutablePair<>(
+                    // @checkstyle MagicNumberCheck (1 line)
+                    2564L, "c1cfc96b4ca50645c57e10b65fcc89fd1b2b79eb495c9fa035613af7ff97dbff"
+                )
+            )
+        );
+    }
+
+}

--- a/src/test/java/com/artipie/debian/misc/RosUnpackedContentTest.java
+++ b/src/test/java/com/artipie/debian/misc/RosUnpackedContentTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test for {@link RosUnpackedContent}.
- * @since 0.5
+ * @since 0.6
  */
 class RosUnpackedContentTest {
 


### PR DESCRIPTION
Part of #89 
Added `RosUnpackedContent` - this class unpacks `gz` and calculates unpacked content digest and size without loading whole archive into memory and does not copy it to temp file.