### PR TITLE
Extracted test class to work with gz

### DIFF
--- a/src/test/java/com/artipie/debian/AstoGzArchive.java
+++ b/src/test/java/com/artipie/debian/AstoGzArchive.java
@@ -1,0 +1,77 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.debian;
+
+import com.artipie.asto.Content;
+import com.artipie.asto.Key;
+import com.artipie.asto.Storage;
+import com.artipie.asto.blocking.BlockingStorage;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * GzArchive: packs or unpacks.
+ * @since 0.4
+ */
+public final class AstoGzArchive {
+
+    /**
+     * Abstract storage.
+     */
+    private final Storage asto;
+
+    /**
+     * Ctor.
+     * @param asto Abstract storage
+     */
+    public AstoGzArchive(final Storage asto) {
+        this.asto = asto;
+    }
+
+    /**
+     * Compress provided bytes in gz format and adds item to storage by provided key.
+     * @param bytes Bytes to pack
+     * @param key Storage key
+     */
+    public void packAndSave(final byte[] bytes, final Key key) {
+        this.asto.save(key, new Content.From(new GzArchive().compress(bytes))).join();
+    }
+
+    /**
+     * Compress provided string in gz format and adds item to storage by provided key.
+     * @param content String to pack
+     * @param key Storage key
+     */
+    public void packAndSave(final String content, final Key key) {
+        this.packAndSave(content.getBytes(StandardCharsets.UTF_8), key);
+    }
+
+    /**
+     * Unpacks storage item and returns unpacked content as string.
+     * @param key Storage item
+     * @return Unpacked string
+     */
+    public String unpack(final Key key) {
+        return new GzArchive().decompress(new BlockingStorage(this.asto).value(key));
+    }
+}

--- a/src/test/java/com/artipie/debian/AstoGzArchive.java
+++ b/src/test/java/com/artipie/debian/AstoGzArchive.java
@@ -31,7 +31,7 @@ import java.nio.charset.StandardCharsets;
 
 /**
  * GzArchive: packs or unpacks.
- * @since 0.4
+ * @since 0.6
  */
 public final class AstoGzArchive {
 

--- a/src/test/java/com/artipie/debian/DebianTest.java
+++ b/src/test/java/com/artipie/debian/DebianTest.java
@@ -129,7 +129,7 @@ class DebianTest {
         ).toCompletableFuture().join();
         MatcherAssert.assertThat(
             "Generates Packages index",
-            new GzArchive(this.storage).unpack(DebianTest.PACKAGES),
+            new AstoGzArchive(this.storage).unpack(DebianTest.PACKAGES),
             new AllOf<>(
                 new ListOf<Matcher<? super String>>(
                     new StringContains("\n\n"),
@@ -173,12 +173,12 @@ class DebianTest {
         final String pckg = "pspp_1.2.0-3_amd64.deb";
         final Key.From key = new Key.From("some_repo", pckg);
         new TestResource(pckg).saveTo(this.storage, key);
-        new GzArchive(this.storage).packAndSave(this.aglfn(), DebianTest.PACKAGES);
+        new AstoGzArchive(this.storage).packAndSave(this.aglfn(), DebianTest.PACKAGES);
         this.debian.updatePackages(new ListOf<>(key), DebianTest.PACKAGES)
             .toCompletableFuture().join();
         MatcherAssert.assertThat(
             "Packages index was updated",
-            new GzArchive(this.storage).unpack(DebianTest.PACKAGES),
+            new AstoGzArchive(this.storage).unpack(DebianTest.PACKAGES),
             new AllOf<>(
                 new ListOf<Matcher<? super String>>(
                     new StringContains("\n\n"),

--- a/src/test/java/com/artipie/debian/GzArchive.java
+++ b/src/test/java/com/artipie/debian/GzArchive.java
@@ -23,89 +23,60 @@
  */
 package com.artipie.debian;
 
-import com.artipie.asto.Content;
-import com.artipie.asto.Key;
-import com.artipie.asto.Storage;
-import com.artipie.asto.blocking.BlockingStorage;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
 
 /**
- * GzArchive: packs or unpacks.
- * @since 0.4
- * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ * Class to work with gz: pack and unpack bytes.
+ * @since 0.6
+ * @checkstyle NonStaticMethodCheck (500 lines)
  */
 public final class GzArchive {
 
     /**
-     * Abstract storage.
+     * Compresses provided bytes in gz format.
+     * @param data Bytes to pack
+     * @return Packed bytes
      */
-    private final Storage asto;
-
-    /**
-     * Ctor.
-     * @param asto Abstract storage
-     */
-    public GzArchive(final Storage asto) {
-        this.asto = asto;
-    }
-
-    /**
-     * Compress provided bytes in gz format and adds item to storage by provided key.
-     * @param bytes Bytes to pack
-     * @param key Storage key
-     */
-    public void packAndSave(final byte[] bytes, final Key key) {
+    public byte[] compress(final byte[] data) {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try (GzipCompressorOutputStream gcos =
             new GzipCompressorOutputStream(new BufferedOutputStream(baos))) {
-            gcos.write(bytes);
+            gcos.write(data);
         } catch (final IOException err) {
             throw new UncheckedIOException(err);
         }
-        this.asto.save(key, new Content.From(baos.toByteArray())).join();
+        return baos.toByteArray();
     }
 
     /**
-     * Compress provided string in gz format and adds item to storage by provided key.
-     * @param content String to pack
-     * @param key Storage key
-     */
-    public void packAndSave(final String content, final Key key) {
-        this.packAndSave(content.getBytes(StandardCharsets.UTF_8), key);
-    }
-
-    /**
-     * Unpacks storage item and returns unpacked content as string.
-     * @param key Storage item
-     * @return Unpacked string
+     * Decompresses provided gz packed data.
+     * @param data Bytes to unpack
+     * @return Unpacked data in string format
      * @checkstyle MagicNumberCheck (15 lines)
      */
     @SuppressWarnings("PMD.AssignmentInOperand")
-    public String unpack(final Key key) {
+    public String decompress(final byte[] data) {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
         try (
             GzipCompressorInputStream gcis = new GzipCompressorInputStream(
-                new BufferedInputStream(
-                    new ByteArrayInputStream(new BlockingStorage(this.asto).value(key))
-                )
+                new BufferedInputStream(new ByteArrayInputStream(data))
             )
         ) {
-            final ByteArrayOutputStream out = new ByteArrayOutputStream();
             final byte[] buf = new byte[1024];
             int cnt;
             while (-1 != (cnt = gcis.read(buf))) {
                 out.write(buf, 0, cnt);
             }
-            return out.toString();
         } catch (final IOException err) {
             throw new UncheckedIOException(err);
         }
+        return out.toString();
     }
 }

--- a/src/test/java/com/artipie/debian/GzArchive.java
+++ b/src/test/java/com/artipie/debian/GzArchive.java
@@ -34,7 +34,7 @@ import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
 
 /**
  * Class to work with gz: pack and unpack bytes.
- * @since 0.6
+ * @since 0.4
  * @checkstyle NonStaticMethodCheck (500 lines)
  */
 public final class GzArchive {

--- a/src/test/java/com/artipie/debian/http/UpdateSliceTest.java
+++ b/src/test/java/com/artipie/debian/http/UpdateSliceTest.java
@@ -30,8 +30,8 @@ import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.asto.test.TestResource;
+import com.artipie.debian.AstoGzArchive;
 import com.artipie.debian.Config;
-import com.artipie.debian.GzArchive;
 import com.artipie.http.Headers;
 import com.artipie.http.hm.RsHasStatus;
 import com.artipie.http.hm.SliceHasResponse;
@@ -145,7 +145,7 @@ class UpdateSliceTest {
             new IsEqual<>(true)
         );
         MatcherAssert.assertThat(
-            new GzArchive(this.asto).unpack(key),
+            new AstoGzArchive(this.asto).unpack(key),
             new StringContainsInOrder(
                 new ListOf<String>(
                     "Package: aglfn",

--- a/src/test/java/com/artipie/debian/metadata/PackageAstoTest.java
+++ b/src/test/java/com/artipie/debian/metadata/PackageAstoTest.java
@@ -27,7 +27,7 @@ import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.asto.test.TestResource;
-import com.artipie.debian.GzArchive;
+import com.artipie.debian.AstoGzArchive;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -72,7 +72,7 @@ class PackageAstoTest {
             .toCompletableFuture().join();
         MatcherAssert.assertThat(
             "Packages index has info about 3 packages",
-            new GzArchive(this.asto).unpack(new Key.From(PackageAstoTest.KEY)),
+            new AstoGzArchive(this.asto).unpack(new Key.From(PackageAstoTest.KEY)),
             new StringContainsInOrder(
                 new ListOf<String>(
                     "Package: aglfn",
@@ -94,7 +94,7 @@ class PackageAstoTest {
         ).toCompletableFuture().join();
         MatcherAssert.assertThat(
             "Packages index has info about 4 packages",
-            new GzArchive(this.asto).unpack(new Key.From(PackageAstoTest.KEY)),
+            new AstoGzArchive(this.asto).unpack(new Key.From(PackageAstoTest.KEY)),
             new StringContainsInOrder(
                 new ListOf<String>(
                     "Package: aglfn",
@@ -116,7 +116,7 @@ class PackageAstoTest {
             .toCompletableFuture().join();
         MatcherAssert.assertThat(
             "Packages index was created with added package",
-            new GzArchive(this.asto).unpack(new Key.From(PackageAstoTest.KEY)),
+            new AstoGzArchive(this.asto).unpack(new Key.From(PackageAstoTest.KEY)),
             new StringContains(this.firstPackageInfo())
         );
     }
@@ -130,7 +130,7 @@ class PackageAstoTest {
             ).toCompletableFuture().join();
         MatcherAssert.assertThat(
             "Packages index was created with added packages",
-            new GzArchive(this.asto).unpack(new Key.From(PackageAstoTest.KEY)),
+            new AstoGzArchive(this.asto).unpack(new Key.From(PackageAstoTest.KEY)),
             new StringContainsInOrder(
                 new ListOf<String>(
                     this.firstPackageInfo(),

--- a/src/test/java/com/artipie/debian/metadata/ReleaseAstoTest.java
+++ b/src/test/java/com/artipie/debian/metadata/ReleaseAstoTest.java
@@ -31,8 +31,8 @@ import com.artipie.asto.Storage;
 import com.artipie.asto.ext.PublisherAs;
 import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.asto.test.TestResource;
+import com.artipie.debian.AstoGzArchive;
 import com.artipie.debian.Config;
-import com.artipie.debian.GzArchive;
 import com.artipie.http.slice.KeyFromPath;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -152,7 +152,7 @@ class ReleaseAstoTest {
             new Key.From("dists/my-deb/main/binary-amd64/Packages.gz"), Content.EMPTY
         ).join();
         final Key key = new Key.From("dists/my-deb/main/binary-intel/Packages.gz");
-        new GzArchive(this.asto).packAndSave("abc123", key);
+        new AstoGzArchive(this.asto).packAndSave("abc123", key);
         final ListOf<String> content = new ListOf<>(
             "Codename: my-deb",
             "Architectures: amd64 intel",
@@ -196,7 +196,7 @@ class ReleaseAstoTest {
             new Key.From("dists/my-repo/main/binary-amd64/Packages.gz"), Content.EMPTY
         ).join();
         final Key key = new Key.From("dists/my-repo/main/binary-intel/Packages.gz");
-        new GzArchive(this.asto).packAndSave("xyz", key);
+        new AstoGzArchive(this.asto).packAndSave("xyz", key);
         final ListOf<String> content = new ListOf<>(
             "Codename: my-repo",
             "Architectures: amd64 intel",
@@ -238,7 +238,7 @@ class ReleaseAstoTest {
             new Key.From("dists/deb-test/main/binary-amd64/Packages.gz"), Content.EMPTY
         ).join();
         final Key key = new Key.From("dists/deb-test/main/binary-intel/Packages.gz");
-        new GzArchive(this.asto).packAndSave("098", key);
+        new AstoGzArchive(this.asto).packAndSave("098", key);
         final ListOf<String> content = new ListOf<>(
             "Codename: deb-test",
             "Architectures: amd64 intel",

--- a/src/test/java/com/artipie/debian/metadata/UniquePackageTest.java
+++ b/src/test/java/com/artipie/debian/metadata/UniquePackageTest.java
@@ -28,7 +28,7 @@ import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.asto.test.TestResource;
-import com.artipie.debian.GzArchive;
+import com.artipie.debian.AstoGzArchive;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -77,11 +77,11 @@ class UniquePackageTest {
         new TestResource(UniquePackageTest.PCKG).saveTo(temp);
         MatcherAssert.assertThat(
             "Packages index has info about 3 packages",
-            new GzArchive(this.asto).unpack(UniquePackageTest.KEY),
+            new AstoGzArchive(this.asto).unpack(UniquePackageTest.KEY),
             new IsEqual<>(
                 String.join(
                     "\n\n",
-                    new GzArchive(temp).unpack(UniquePackageTest.KEY),
+                    new AstoGzArchive(temp).unpack(UniquePackageTest.KEY),
                     this.abcPackageInfo()
                 )
             )
@@ -93,7 +93,7 @@ class UniquePackageTest {
     void replacesOneExistingPackage() throws IOException {
         final Key old = new Key.From("abc/old/package.deb");
         this.asto.save(old, Content.EMPTY).join();
-        new GzArchive(this.asto).packAndSave(
+        new AstoGzArchive(this.asto).packAndSave(
             this.abcPackageInfo(old.string()),
             UniquePackageTest.KEY
         );
@@ -102,7 +102,7 @@ class UniquePackageTest {
             .toCompletableFuture().join();
         MatcherAssert.assertThat(
             "Packages index has info about 1 package",
-            new GzArchive(this.asto).unpack(UniquePackageTest.KEY),
+            new AstoGzArchive(this.asto).unpack(UniquePackageTest.KEY),
             new IsEqual<>(this.abcPackageInfo())
         );
         this.verifyOldPackageWasRemoved(old);
@@ -112,13 +112,13 @@ class UniquePackageTest {
     @Test
     void doesNotReplacePackageWithAnotherVersion() throws IOException {
         final String second = this.abcPackageInfo().replace("Version: 0.1", "Version: 0.2");
-        new GzArchive(this.asto).packAndSave(second, UniquePackageTest.KEY);
+        new AstoGzArchive(this.asto).packAndSave(second, UniquePackageTest.KEY);
         new UniquePackage(this.asto)
             .add(new ListOf<>(this.abcPackageInfo()), UniquePackageTest.KEY)
             .toCompletableFuture().join();
         MatcherAssert.assertThat(
             "Packages index has info about 2 packages",
-            new GzArchive(this.asto).unpack(UniquePackageTest.KEY),
+            new AstoGzArchive(this.asto).unpack(UniquePackageTest.KEY),
             new IsEqual<>(String.join("\n\n", second, this.abcPackageInfo()))
         );
         this.verifyThatTempDirIsCleanedUp();
@@ -128,7 +128,7 @@ class UniquePackageTest {
     void replacesFirstDuplicatedPackage() throws IOException {
         final Key old = new Key.From("zero/old/package.deb");
         this.asto.save(old, Content.EMPTY).join();
-        new GzArchive(this.asto).packAndSave(
+        new AstoGzArchive(this.asto).packAndSave(
             String.join(
                 "\n\n",
                 this.zeroPackageInfo(old.string()),
@@ -143,7 +143,7 @@ class UniquePackageTest {
             ).toCompletableFuture().join();
         MatcherAssert.assertThat(
             "Packages index has info about 3 packages",
-            new GzArchive(this.asto).unpack(UniquePackageTest.KEY),
+            new AstoGzArchive(this.asto).unpack(UniquePackageTest.KEY),
             new IsEqual<>(
                 String.join(
                     "\n\n", this.xyzPackageInfo(), this.zeroPackageInfo(), this.abcPackageInfo()
@@ -158,7 +158,7 @@ class UniquePackageTest {
     void replacesLastDuplicatedPackage() throws IOException {
         final Key old = new Key.From("zero/one/two/package.deb");
         this.asto.save(old, Content.EMPTY).join();
-        new GzArchive(this.asto).packAndSave(
+        new AstoGzArchive(this.asto).packAndSave(
             String.join(
                 "\n\n",
                 this.abcPackageInfo(),
@@ -173,7 +173,7 @@ class UniquePackageTest {
             ).toCompletableFuture().join();
         MatcherAssert.assertThat(
             "Packages index has info about 3 packages",
-            new GzArchive(this.asto).unpack(UniquePackageTest.KEY),
+            new AstoGzArchive(this.asto).unpack(UniquePackageTest.KEY),
             new IsEqual<>(
                 String.join(
                     "\n\n", this.abcPackageInfo(), this.xyzPackageInfo(), this.zeroPackageInfo()
@@ -188,7 +188,7 @@ class UniquePackageTest {
     void replacesMiddleDuplicatedPackage() throws IOException {
         final Key old = new Key.From("zero/one/one/package.deb");
         this.asto.save(old, Content.EMPTY).join();
-        new GzArchive(this.asto).packAndSave(
+        new AstoGzArchive(this.asto).packAndSave(
             String.join(
                 "\n\n",
                 this.abcPackageInfo(),
@@ -204,7 +204,7 @@ class UniquePackageTest {
             ).toCompletableFuture().join();
         MatcherAssert.assertThat(
             "Packages index has info about 3 packages",
-            new GzArchive(this.asto).unpack(UniquePackageTest.KEY),
+            new AstoGzArchive(this.asto).unpack(UniquePackageTest.KEY),
             new IsEqual<>(
                 String.join(
                     "\n\n", this.abcPackageInfo(), this.xyzPackageInfo(), this.zeroPackageInfo()
@@ -221,7 +221,7 @@ class UniquePackageTest {
         this.asto.save(one, Content.EMPTY).join();
         final Key two = new Key.From("two/abc/package.deb");
         this.asto.save(two, Content.EMPTY).join();
-        new GzArchive(this.asto).packAndSave(
+        new AstoGzArchive(this.asto).packAndSave(
             String.join(
                 "\n\n",
                 this.abcPackageInfo(two.string()),
@@ -237,7 +237,7 @@ class UniquePackageTest {
             ).toCompletableFuture().join();
         MatcherAssert.assertThat(
             "Packages index has info about 3 packages",
-            new GzArchive(this.asto).unpack(UniquePackageTest.KEY),
+            new AstoGzArchive(this.asto).unpack(UniquePackageTest.KEY),
             new IsEqual<>(
                 String.join(
                     "\n\n", this.xyzPackageInfo(), this.abcPackageInfo(), this.zeroPackageInfo()

--- a/src/test/java/com/artipie/debian/metadata/UniquePackageTest.java
+++ b/src/test/java/com/artipie/debian/metadata/UniquePackageTest.java
@@ -254,7 +254,7 @@ class UniquePackageTest {
         this.asto.save(one, Content.EMPTY).join();
         final Key two = new Key.From("two/abc/0.2/package.deb");
         this.asto.save(two, Content.EMPTY).join();
-        new GzArchive(this.asto).packAndSave(
+        new AstoGzArchive(this.asto).packAndSave(
             String.join(
                 "\n\n",
                 this.abcPackageInfo(one.string()),
@@ -271,7 +271,7 @@ class UniquePackageTest {
         ).toCompletableFuture().join();
         MatcherAssert.assertThat(
             "Packages index has info about 3 packages",
-            new GzArchive(this.asto).unpack(UniquePackageTest.KEY),
+            new AstoGzArchive(this.asto).unpack(UniquePackageTest.KEY),
             new IsEqual<>(
                 String.join(
                     "\n\n",


### PR DESCRIPTION
Part of #87 
Extracted test class to work with gz archives without storage: renamed `GzArchive` into `AstoGzArchive` and used `GzArchive` in `MultiDebianTest` and `AstoGzArchive`.