### PR TITLE
Skip extra empty lines on Packages update/merge

### DIFF
--- a/src/main/java/com/artipie/debian/MultiPackages.java
+++ b/src/main/java/com/artipie/debian/MultiPackages.java
@@ -89,7 +89,7 @@ public interface MultiPackages {
             StringBuilder item = new StringBuilder();
             do {
                 line = rdr.readLine();
-                if (line == null || line.isEmpty()) {
+                if ((line == null || line.isEmpty()) && item.length() > 0) {
                     final Pair<String, String> pair = new ImmutablePair<>(
                         new ControlField.Package().value(item.toString()).get(0),
                         new ControlField.Version().value(item.toString()).get(0)
@@ -99,7 +99,7 @@ public interface MultiPackages {
                         packages.add(pair);
                     }
                     item = new StringBuilder();
-                } else {
+                } else if (line != null && !line.isEmpty()) {
                     item.append(line).append('\n');
                 }
             } while (line != null);

--- a/src/main/java/com/artipie/debian/metadata/UniquePackage.java
+++ b/src/main/java/com/artipie/debian/metadata/UniquePackage.java
@@ -163,7 +163,7 @@ public final class UniquePackage implements Package {
             StringBuilder item = new StringBuilder();
             do {
                 line = rdr.readLine();
-                if (line == null || line.isEmpty()) {
+                if ((line == null || line.isEmpty()) && item.length() > 0) {
                     final Optional<String> dupl = UniquePackage.duplicate(item.toString(), newbies);
                     if (dupl.isPresent()) {
                         duplicates.add(dupl.get());
@@ -171,7 +171,7 @@ public final class UniquePackage implements Package {
                         gop.write(item.append('\n').toString().getBytes(StandardCharsets.UTF_8));
                     }
                     item = new StringBuilder();
-                } else {
+                } else if (line != null && !line.isEmpty()) {
                     item.append(line).append('\n');
                 }
             } while (line != null);

--- a/src/test/java/com/artipie/debian/MultiPackagesTest.java
+++ b/src/test/java/com/artipie/debian/MultiPackagesTest.java
@@ -99,6 +99,26 @@ class MultiPackagesTest {
         );
     }
 
+    @Test
+    void handlesExtraLineBreaks() throws IOException {
+        final ByteArrayOutputStream res = new ByteArrayOutputStream();
+        new MultiPackages.Unique().merge(
+            new ListOf<InputStream>(
+                this.stream(String.join("\n\n\n", this.abcPackageInfo(), this.zeroPackageInfo())),
+                this.stream(String.format("%s\n\n", this.xyzPackageInfo()))
+            ),
+            res
+        );
+        MatcherAssert.assertThat(
+            new GzArchive().decompress(res.toByteArray()),
+            new IsEqual<>(
+                String.join(
+                    "\n\n", this.abcPackageInfo(), this.zeroPackageInfo(), this.xyzPackageInfo(), ""
+                )
+            )
+        );
+    }
+
     private String xyzPackageInfo() {
         return String.join(
             "\n",
@@ -145,10 +165,12 @@ class MultiPackagesTest {
     }
 
     private InputStream stream(final String... items) {
+        return this.stream(StringUtils.join(items, "\n\n"));
+    }
+
+    private InputStream stream(final String item) {
         return new ByteArrayInputStream(
-            new GzArchive().compress(
-                StringUtils.join(items, "\n\n").getBytes(StandardCharsets.UTF_8)
-            )
+            new GzArchive().compress(item.getBytes(StandardCharsets.UTF_8))
         );
     }
 

--- a/src/test/java/com/artipie/debian/metadata/UniquePackageTest.java
+++ b/src/test/java/com/artipie/debian/metadata/UniquePackageTest.java
@@ -300,10 +300,7 @@ class UniquePackageTest {
             .add(
                 new ListOf<>(String.format("%s\n\n", this.xyzPackageInfo())),
                 UniquePackageTest.KEY
-            )
-            .toCompletableFuture().join();
-        final Storage temp = new InMemoryStorage();
-        new TestResource(UniquePackageTest.PCKG).saveTo(temp);
+            ).toCompletableFuture().join();
         MatcherAssert.assertThat(
             "Packages index has info about 3 packages",
             new AstoGzArchive(this.asto).unpack(UniquePackageTest.KEY),

--- a/src/test/java/com/artipie/debian/metadata/UniquePackageTest.java
+++ b/src/test/java/com/artipie/debian/metadata/UniquePackageTest.java
@@ -285,6 +285,41 @@ class UniquePackageTest {
         this.verifyThatTempDirIsCleanedUp();
     }
 
+    @Test
+    void handlesExtraLineBreaks() throws IOException {
+        new AstoGzArchive(this.asto).packAndSave(
+            String.join(
+                "\n\n\n",
+                this.abcPackageInfo(),
+                this.zeroPackageInfo(),
+                ""
+            ),
+            UniquePackageTest.KEY
+        );
+        new UniquePackage(this.asto)
+            .add(
+                new ListOf<>(String.format("%s\n\n", this.xyzPackageInfo())),
+                UniquePackageTest.KEY
+            )
+            .toCompletableFuture().join();
+        final Storage temp = new InMemoryStorage();
+        new TestResource(UniquePackageTest.PCKG).saveTo(temp);
+        MatcherAssert.assertThat(
+            "Packages index has info about 3 packages",
+            new AstoGzArchive(this.asto).unpack(UniquePackageTest.KEY),
+            new IsEqual<>(
+                String.join(
+                    "\n\n",
+                    this.abcPackageInfo(),
+                    this.zeroPackageInfo(),
+                    this.xyzPackageInfo(),
+                    ""
+                )
+            )
+        );
+        this.verifyThatTempDirIsCleanedUp();
+    }
+
     private void verifyThatTempDirIsCleanedUp() throws IOException {
         final Path systemtemp = Paths.get(System.getProperty("java.io.tmpdir"));
         MatcherAssert.assertThat(


### PR DESCRIPTION
CLoses #96 
While updating or merging `Packages` index extra empty lines should be skipped, corrected code and added corresponding tests.