### PR TITLE
Updated asto, used `StorageValuePipeline` in `Package.Asto`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>asto</artifactId>
-      <version>v1.4.0</version>
+      <version>v1.5.1</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>


### PR DESCRIPTION
Part of #89 
Updated asto and `StorageValuePipeline` in `Package.Asto` to avoid temp files.