### PR TITLE
Updated asto, used `StorageValuePipeline` in `UniquePackage`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>asto</artifactId>
-      <version>v1.5.1</version>
+      <version>v1.6.0</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>

--- a/src/main/java/com/artipie/debian/metadata/Package.java
+++ b/src/main/java/com/artipie/debian/metadata/Package.java
@@ -63,7 +63,7 @@ public interface Package {
             return CompletableFuture.supplyAsync(
                 () -> String.join(Asto.SEP, items).getBytes(StandardCharsets.UTF_8)
             ).thenCompose(
-                bytes -> new StorageValuePipeline(this.asto, index).process(
+                bytes -> new StorageValuePipeline<>(this.asto, index).process(
                     (opt, out) -> {
                         if (opt.isPresent()) {
                             Asto.decompressAppendCompress(opt.get(), out, bytes);

--- a/src/main/java/com/artipie/debian/metadata/UniquePackage.java
+++ b/src/main/java/com/artipie/debian/metadata/UniquePackage.java
@@ -175,9 +175,7 @@ public final class UniquePackage implements Package {
      * @param res Output stream to write the result
      */
     private static void compress(final Iterable<String> items, final OutputStream res) {
-        try (GzipCompressorOutputStream gcos =
-            new GzipCompressorOutputStream(new BufferedOutputStream(res))
-        ) {
+        try (GzipCompressorOutputStream gcos = new GzipCompressorOutputStream(res)) {
             gcos.write(String.join(UniquePackage.SEP, items).getBytes(StandardCharsets.UTF_8));
         } catch (final IOException err) {
             throw new UncheckedIOException(err);


### PR DESCRIPTION
Part of #89 
Used `StorageValuePipeline` in `UniquePackage` to avoid temp files.