### PR TITLE
Update parent pom

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -27,14 +27,14 @@ SOFTWARE.
   <parent>
     <groupId>com.artipie</groupId>
     <artifactId>ppom</artifactId>
-    <version>0.5.1</version>
+    <version>1.1.0</version>
   </parent>
   <artifactId>debian-bench</artifactId>
   <version>1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <properties>
     <jmh.version>1.29</jmh.version>
-    <asto.version>v1.8.0</asto.version>
+    <asto.version>v1.9.0</asto.version>
   </properties>
   <dependencies>
     <dependency>
@@ -76,6 +76,14 @@ SOFTWARE.
         </configuration>
       </plugin>
       <plugin>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <configuration>
+            <useFile>false</useFile>
+            <trimStackTrace>false</trimStackTrace>
+            <failIfNoTests>false</failIfNoTests>
+          </configuration>
+        </plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <version>3.2.0</version>

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -76,14 +76,14 @@ SOFTWARE.
         </configuration>
       </plugin>
       <plugin>
-        <plugin>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <configuration>
-            <useFile>false</useFile>
-            <trimStackTrace>false</trimStackTrace>
-            <failIfNoTests>false</failIfNoTests>
-          </configuration>
-        </plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <useFile>false</useFile>
+          <trimStackTrace>false</trimStackTrace>
+          <failIfNoTests>false</failIfNoTests>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <version>3.2.0</version>

--- a/benchmarks/src/main/java/com/artipie/debian/benchmarks/IndexMergeBench.java
+++ b/benchmarks/src/main/java/com/artipie/debian/benchmarks/IndexMergeBench.java
@@ -5,6 +5,7 @@
 
 package com.artipie.debian.benchmarks;
 
+import com.artipie.asto.misc.UncheckedIOFunc;
 import com.artipie.debian.MultiPackages;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -16,7 +17,6 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.cactoos.scalar.Unchecked;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Measurement;
@@ -61,9 +61,8 @@ public class IndexMergeBench {
             throw new IllegalStateException("BENCH_DIR environment variable must be set");
         }
         try (Stream<Path> files = Files.list(Paths.get(IndexMergeBench.BENCH_DIR))) {
-            this.input = files.map(
-                path -> new Unchecked<>(() -> Files.readAllBytes(path)).value()
-            ).collect(Collectors.toList());
+            this.input = files.map(new UncheckedIOFunc<>(Files::readAllBytes))
+                .collect(Collectors.toList());
         }
     }
 

--- a/benchmarks/src/main/java/com/artipie/debian/benchmarks/RepoUpdateBench.java
+++ b/benchmarks/src/main/java/com/artipie/debian/benchmarks/RepoUpdateBench.java
@@ -9,6 +9,7 @@ import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.memory.BenchmarkStorage;
 import com.artipie.asto.memory.InMemoryStorage;
+import com.artipie.asto.misc.UncheckedIOScalar;
 import com.artipie.debian.Config;
 import com.artipie.debian.Debian;
 import java.io.IOException;
@@ -20,7 +21,6 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
-import org.cactoos.scalar.Unchecked;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Measurement;
@@ -84,7 +84,7 @@ public class RepoUpdateBench {
                     this.readonly.save(
                         key,
                         new Content.From(
-                            new Unchecked<>(() -> Files.readAllBytes(item)).value()
+                            new UncheckedIOScalar<>(() -> Files.readAllBytes(item)).value()
                         )
                     ).join();
                     if (key.string().endsWith(".deb")) {

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@ SOFTWARE.
   <parent>
     <groupId>com.artipie</groupId>
     <artifactId>ppom</artifactId>
-    <version>0.5.1</version>
+    <version>1.1.0</version>
   </parent>
   <artifactId>debian-adapter</artifactId>
   <version>1.0-SNAPSHOT</version>
@@ -104,17 +104,17 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>http</artifactId>
-      <version>0.17.5</version>
+      <version>v1.0.1</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>asto</artifactId>
-      <version>v1.8.0</version>
+      <version>v1.9.0</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>vertx-server</artifactId>
-      <version>0.4</version>
+      <version>0.5</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>
@@ -181,6 +181,12 @@ SOFTWARE.
       <artifactId>xz</artifactId>
       <version>1.8</version>
       <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.cactoos</groupId>
+      <artifactId>cactoos</artifactId>
+      <version>0.50</version>
+      <scope>test</scope>
     </dependency>
     <!-- Dependency for PGP and GPG Encryption-Decryption -->
     <dependency>

--- a/src/main/java/com/artipie/debian/http/UpdateSlice.java
+++ b/src/main/java/com/artipie/debian/http/UpdateSlice.java
@@ -24,13 +24,13 @@ import com.artipie.http.rs.RsWithStatus;
 import com.artipie.http.rs.StandardRs;
 import com.artipie.http.slice.KeyFromPath;
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import org.cactoos.list.ListOf;
 import org.reactivestreams.Publisher;
 
 /**
@@ -121,7 +121,7 @@ public final class UpdateSlice implements Slice {
                     )
                 ).map(
                     index -> new UniquePackage(this.asto)
-                        .add(new ListOf<>(item), new Key.From(index))
+                        .add(Collections.singleton(item), new Key.From(index))
                         .thenCompose(nothing -> release.update(new Key.From(index)))
                 ).toArray(CompletableFuture[]::new)
             ).thenCompose(

--- a/src/main/java/com/artipie/debian/metadata/ControlField.java
+++ b/src/main/java/com/artipie/debian/metadata/ControlField.java
@@ -4,10 +4,10 @@
  */
 package com.artipie.debian.metadata;
 
+import com.google.common.collect.Lists;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.stream.Stream;
-import org.cactoos.list.ListOf;
 
 /**
  * Control file field.
@@ -49,7 +49,7 @@ public interface ControlField {
                 //@checkstyle StringLiteralsConcatenationCheck (1 line)
                 .map(item -> item.substring(item.indexOf(":") + 2))
                 .map(res -> res.split(" "))
-                .map(ListOf::new)
+                .map(Lists::newArrayList)
                 .orElseThrow(
                     () -> new NoSuchElementException(
                         String.format("Field %s not found in control", this.field)


### PR DESCRIPTION
Updated parent pom, vertx-server, http, asto and cactoos is now used only in test scope.